### PR TITLE
feat: wire diagram and evaluator nodes to Design Ledger (P5)

### DIFF
--- a/back/src/graph/nodes/diagram.py
+++ b/back/src/graph/nodes/diagram.py
@@ -23,6 +23,12 @@ from src.services.diagram_ir import (
     to_detail_level,
 )
 from src.services.diagram_render import render_dot, render_dot_drawio, render_svg_b64
+from src.ledger import (
+    append_decision, compute_active_view, load_ledger,
+    render_dossier, render_dossier_compact, render_phase_prompt,
+    LedgerValidationError, LedgerConcurrencyError,
+)
+from src.ledger.types import Phase
 
 try:
     from graphviz import Source
@@ -131,6 +137,44 @@ def _resolve_diagram_level(state: GraphState, user_q: str) -> DiagramLevel:
             log.warning("diagram_orchestrator_node: invalid diagram level override %r", level_override)
 
     return _infer_level_from_user_request(user_q)
+
+
+def _build_diagram_parent_refs(state: GraphState) -> list[dict]:
+    """Extract style + tactic refs from ledger_active for diagram parents."""
+    active = state.get("ledger_active") or {}
+    refs = []
+    style = active.get("style")
+    if style and style.get("id"):
+        refs.append({"id": style["id"], "kind": "style", "iteration": style.get("iteration", 0)})
+    tactic = active.get("tactic")
+    if tactic and tactic.get("id"):
+        refs.append({"id": tactic["id"], "kind": "tactic", "iteration": tactic.get("iteration", 0)})
+    return refs
+
+
+def _build_diagram_payload(diagram_obj: dict) -> dict:
+    """Map diagram_orchestrator output to ledger payload contract."""
+    return {
+        "level": diagram_obj.get("level"),
+        "dot": diagram_obj.get("dot", ""),
+        "dot_drawio": diagram_obj.get("dot_drawio", ""),
+        "svg_b64": diagram_obj.get("svg_b64", ""),
+        "focus": diagram_obj.get("detail_level", ""),
+        "mapping": diagram_obj.get("overview_mapping"),
+    }
+
+
+def _refresh_ledger_state(state: GraphState, user_id: str, project_id: str | None, lang: str) -> None:
+    """Reload ledger into state after a successful append_decision."""
+    ledger = load_ledger(user_id, project_id)
+    active = compute_active_view(ledger)
+    state["ledger"] = ledger
+    state["ledger_active"] = active
+    state["design_dossier_md"] = render_dossier(ledger, lang=lang)
+    state["current_phase"] = ledger.get("current_phase", "INTAKE")
+    state["ledger_dossier_compact"] = render_dossier_compact(ledger, lang=lang)
+    state["ledger_phase_prompt"] = render_phase_prompt(ledger, lang=lang)
+    state["ledger_pending_advance"] = ledger.get("pending_advance") or {}
 
 
 def diagram_orchestrator_node(state: GraphState) -> GraphState:
@@ -275,4 +319,41 @@ def diagram_orchestrator_node(state: GraphState) -> GraphState:
     state["diagram_history"] = diagram_history
     state["hasVisitedDiagram"] = True
     state["intent"] = "diagram"
+
+    # --- Ledger write-back (nonfatal) ---
+    _user_id = state.get("user_id_for_prefs") or ""
+    _project_id = state.get("project_id")
+    _lang = (state.get("language") or "es")
+    if _user_id and diagram_obj.get("ok"):
+        _qa = (
+            (state.get("ledger_active") or {}).get("asr", {}) or {}
+        ).get("qa", state.get("quality_attribute", ""))
+        _parent_refs = _build_diagram_parent_refs(state)
+        try:
+            append_decision(_user_id, _project_id, {
+                "id": "",
+                "kind": "diagram",
+                "phase": state.get("current_phase") or Phase.DIAGRAM,
+                "iteration": 0,
+                "qa": _qa,
+                "parents": _parent_refs,
+                "payload": _build_diagram_payload(diagram_obj),
+                "rationale": f"Level {diagram_obj.get('level')} diagram generated for {_qa or 'current design'}",
+                "sources": [],
+                "status": "active",
+                "parent_status": "ok",
+                "superseded_by": None,
+                "rejection_reason": None,
+                "created_at": "",
+                "created_by_node": "diagram_orchestrator_node",
+            })
+            _refresh_ledger_state(state, _user_id, _project_id, _lang)
+            log.info("diagram_orchestrator_node: ledger write ok — kind=diagram qa=%s", _qa)
+        except LedgerValidationError as exc:
+            log.warning("diagram_orchestrator_node: ledger validation error: %s", exc)
+        except LedgerConcurrencyError as exc:
+            log.warning("diagram_orchestrator_node: ledger concurrency error: %s", exc)
+        except Exception as exc:
+            log.warning("diagram_orchestrator_node: ledger write failed: %s", exc)
+
     return state

--- a/back/src/graph/nodes/evaluator.py
+++ b/back/src/graph/nodes/evaluator.py
@@ -4,11 +4,16 @@ from langchain_core.messages import AIMessage, SystemMessage
 from langgraph.prebuilt import create_react_agent
 
 from src.graph.state import GraphState
-from src.graph.resources import llm, retriever, _HAS_VERTEX
+from src.graph.resources import llm, log, retriever, _HAS_VERTEX
 from src.graph.consts import MARKDOWN_FORMAT_DIRECTIVE
 from src.graph.utils import _push_turn
 from src.graph.nodes.supervisor import _looks_like_eval
 from src.graph.nodes.tools import theory_tool, viability_tool, needs_tool, analyze_tool
+from src.ledger import (
+    append_decision, compute_active_view, load_ledger,
+    LedgerValidationError, LedgerConcurrencyError,
+)
+from src.ledger.types import Phase
 
 def _pick_asr_to_evaluate(state: GraphState) -> str:
     if state.get("last_asr"):
@@ -50,6 +55,67 @@ Use:
 - Needs Tool (requirements alignment)
 - Analyze Tool (compare two diagrams){i1}{i2}
 Keep answers short and decisive."""
+
+def _pick_target_decision(state: GraphState) -> tuple[str | None, str | None, str]:
+    """Return (target_id, parent_kind, qa) for the analysis decision.
+
+    Priority: active diagram > active ASR > None.
+    """
+    active = state.get("ledger_active") or {}
+    for kind in ("diagram", "asr"):
+        d = active.get(kind)
+        if d and d.get("id"):
+            return d["id"], kind, d.get("qa", "")
+    return None, None, state.get("quality_attribute", "")
+
+
+def _write_analysis_to_ledger(state: GraphState, eval_text: str) -> None:
+    """Append a kind='analysis' Decision (nonfatal)."""
+    _user_id = state.get("user_id_for_prefs") or ""
+    _project_id = state.get("project_id")
+    if not _user_id:
+        return
+    _target_id, _target_kind, _qa = _pick_target_decision(state)
+    _active = state.get("ledger_active") or {}
+    _parent_refs = []
+    if _target_id and _target_kind:
+        _parent_refs = [{"id": _target_id, "kind": _target_kind,
+                         "iteration": (_active.get(_target_kind) or {}).get("iteration", 0)}]
+    try:
+        append_decision(_user_id, _project_id, {
+            "id": "",
+            "kind": "analysis",
+            "phase": state.get("current_phase") or Phase.ANALYSIS,
+            "iteration": 0,
+            "qa": _qa,
+            "parents": _parent_refs,
+            "payload": {
+                "positive": "",
+                "negative": "",
+                "suggestions": "",
+                "target_id": _target_id or "",
+                "raw_evaluation": eval_text[:2000],
+            },
+            "rationale": f"Evaluation targeting {_target_kind} {_target_id}",
+            "sources": [],
+            "status": "active",
+            "parent_status": "ok",
+            "superseded_by": None,
+            "rejection_reason": None,
+            "created_at": "",
+            "created_by_node": "evaluator_node",
+        })
+        _fresh_ledger = load_ledger(_user_id, _project_id)
+        state["ledger"] = _fresh_ledger
+        state["ledger_active"] = compute_active_view(_fresh_ledger)
+        log.info("evaluator_node: ledger write ok — kind=analysis target=%s", _target_id)
+    except LedgerValidationError as exc:
+        log.warning("evaluator_node: ledger validation error: %s", exc)
+    except LedgerConcurrencyError as exc:
+        log.warning("evaluator_node: ledger concurrency error: %s", exc)
+    except Exception as exc:
+        log.warning("evaluator_node: ledger write failed: %s", exc)
+
 
 def evaluator_node(state: GraphState) -> GraphState:
     lang = state.get("language", "es")
@@ -109,6 +175,7 @@ List 2-5 short items only if grounded by BOOK_SNIPPETS; otherwise write "None".
 
         _push_turn(state, role="system", name="evaluator_system", content=eval_prompt)
         _push_turn(state, role="assistant", name="evaluator", content=content)
+        _write_analysis_to_ledger(state, content)
 
         return {
             **state,
@@ -139,8 +206,11 @@ List 2-5 short items only if grounded by BOOK_SNIPPETS; otherwise write "None".
         "imagePath2": state.get("imagePath2","")
     })
 
+    last_msg_content = ""
     for msg in result["messages"]:
-        _push_turn(state, role="assistant", name="evaluator", content=str(getattr(msg, "content", msg)))
+        last_msg_content = str(getattr(msg, "content", msg))
+        _push_turn(state, role="assistant", name="evaluator", content=last_msg_content)
+    _write_analysis_to_ledger(state, last_msg_content)
 
     return {
         **state,

--- a/back/src/main.py
+++ b/back/src/main.py
@@ -71,6 +71,7 @@ from src.memory import (
 )
 from src.graph.utils import is_explicit_asr_request
 from src.services.doc_ingest import extract_pdf_text
+from src.ledger.store import load_ledger as _load_ledger, compute_active_view as _compute_active_view
 memory_init()
 
 # ===================== Deteccion simple de idioma (ES/EN) ==========================
@@ -336,6 +337,7 @@ async def diagram_export(
     detail_level: str = Query("overview", regex="^(overview|detailed)$"),
     level: Optional[str] = Query(None, description="Diagram level: 1=overview, 2=medium, 3=detailed"),
     focus: Optional[str] = Query(None, description="Overview node ID to expand (optional)"),
+    project_id: Optional[str] = Query(None, description="Project scope for ledger lookup"),
 ):
     """Export the last generated architecture diagram in the requested format.
 
@@ -367,12 +369,26 @@ async def diagram_export(
         render_svg_async as render_svg_async_from_dot,
     )
 
-    # Retrieve the last diagram for this session from memory
+    # P5: read from ledger; fallback to arch_flow for pre-migration sessions
     user_id = session_id
-    arch_flow = load_arch_flow(user_id)
-    last_diagram = arch_flow.get("last_diagram") or {}
+    project_id = (project_id or "").strip() or None
 
-    dot_code = last_diagram.get("dot") or last_diagram.get("dot_raw") or ""
+    ledger = _load_ledger(user_id, project_id)
+    active = _compute_active_view(ledger)
+    diagram_decision = active.get("diagram")
+
+    if diagram_decision:
+        payload = diagram_decision.get("payload") or {}
+        dot_code = payload.get("dot") or payload.get("dot_raw") or ""
+        _detail_level_hint = payload.get("focus") or "overview"
+        _overview_mapping = payload.get("mapping") or {}
+    else:
+        arch_flow = load_arch_flow(user_id, project_id)
+        last_diagram = arch_flow.get("last_diagram") or {}
+        dot_code = last_diagram.get("dot") or last_diagram.get("dot_raw") or ""
+        _detail_level_hint = last_diagram.get("detail_level") or "overview"
+        _overview_mapping = last_diagram.get("overview_mapping") or {}
+
     if not dot_code:
         raise HTTPException(
             status_code=404,
@@ -397,7 +413,7 @@ async def diagram_export(
         detail_level_name = to_detail_level(requested_level).value
 
         if focus:
-            mapping_for_focus = last_diagram.get("overview_mapping") or level_mapping
+            mapping_for_focus = _overview_mapping or level_mapping
             ir_model = build_expanded_view(
                 detailed_model,
                 mapping_for_focus,
@@ -510,14 +526,19 @@ def _stream_post_process(
 
     diagram_obj = result.get("diagram") or {}
     if diagram_obj.get("ok") and diagram_obj.get("dot"):
-        arch_flow["last_diagram"] = {
-            "dot": diagram_obj.get("dot", ""),
-            "dot_raw": diagram_obj.get("dot_raw", ""),
-            "dot_drawio": diagram_obj.get("dot_drawio", ""),
-            "detail_level": diagram_obj.get("detail_level", "overview"),
-            "level": diagram_obj.get("level", 1),
-            "overview_mapping": diagram_obj.get("overview_mapping"),
-        }
+        # P5 guard: skip arch_flow write when ledger already captured the diagram
+        _diagram_in_ledger = bool(
+            (result.get("ledger_active") or {}).get("diagram")
+        )
+        if not _diagram_in_ledger:
+            arch_flow["last_diagram"] = {
+                "dot": diagram_obj.get("dot", ""),
+                "dot_raw": diagram_obj.get("dot_raw", ""),
+                "dot_drawio": diagram_obj.get("dot_drawio", ""),
+                "detail_level": diagram_obj.get("detail_level", "overview"),
+                "level": diagram_obj.get("level", 1),
+                "overview_mapping": diagram_obj.get("overview_mapping"),
+            }
 
     result_diagram_history = result.get("diagram_history") or {}
     if result_diagram_history:


### PR DESCRIPTION
- diagram_orchestrator_node appends a kind="diagram" Decision after a successful render, with style/tactic parent refs and full dot/svg payload
- evaluator_node appends a kind="analysis" Decision pointing to the active diagram or ASR target after each evaluation run
- /diagram/export reads ledger_active first; falls back to arch_flow for pre-P5 sessions; accepts optional project_id param
- _stream_post_process skips arch_flow diagram write when the ledger already captured it