### PR TITLE
fix: keep AI responses in Spanish when user writes in Spanish

### DIFF
--- a/back/src/graph/nodes/asr.py
+++ b/back/src/graph/nodes/asr.py
@@ -229,10 +229,19 @@ def asr_node(state: GraphState) -> GraphState:
 
     book_snippets = _dedupe_snippets(docs_list, max_items=6, max_chars=800)
 
-    directive = "Answer in English." if lang == "en" else "Responde en español."
+    if lang == "en":
+        directive = (
+            "MANDATORY LANGUAGE: English.\n"
+            "Your ENTIRE response MUST be in English. Do not mix languages."
+        )
+    else:
+        directive = (
+            "IDIOMA OBLIGATORIO: español.\n"
+            "Tu respuesta COMPLETA debe estar en español. No mezcles idiomas."
+        )
     style_hint = (state.get("user_style_hint") or "").strip()
     if style_hint:
-        directive = f"{directive} {style_hint}"
+        directive = f"{directive}\n{style_hint}"
 
     ctx = (
         ctx_doc if (doc_only and ctx_doc) else (state.get("add_context") or "")
@@ -244,14 +253,27 @@ def asr_node(state: GraphState) -> GraphState:
         (state.get("design_dossier_md") or "").strip()
     )
     history_clipped = _clip_text(history_block, 1500) if history_block else ""
-    prior_asr_section = (
-        f'\n{"=" * 60}\n'
-        f'PRIOR ASR HISTORY — DO NOT REPEAT THESE DESIGNS:\n'
-        f'{history_clipped}\n\n'
-        f'IMPORTANT: Your new ASR MUST be meaningfully different '
-        f'in at least its Response Measure or Stimulus.\n'
-        f'{"=" * 60}\n'
-    ) if history_clipped else ""
+    if history_clipped:
+        if lang == "en":
+            prior_asr_section = (
+                f'\n{"=" * 60}\n'
+                f'PRIOR ASR HISTORY — DO NOT REPEAT THESE DESIGNS:\n'
+                f'{history_clipped}\n\n'
+                f'IMPORTANT: Your new ASR MUST be meaningfully different '
+                f'in at least its Response Measure or Stimulus.\n'
+                f'{"=" * 60}\n'
+            )
+        else:
+            prior_asr_section = (
+                f'\n{"=" * 60}\n'
+                f'HISTORIAL DE ASR PREVIOS — NO REPITAS ESTOS DISEÑOS:\n'
+                f'{history_clipped}\n\n'
+                f'IMPORTANTE: Tu nuevo ASR DEBE ser notablemente distinto '
+                f'en al menos su Medida de Respuesta o Estímulo.\n'
+                f'{"=" * 60}\n'
+            )
+    else:
+        prior_asr_section = ""
 
     prompt = f"""{directive}
 You are an expert software architect following Attribute-Driven Design 3.0 (ADD 3.0).
@@ -314,6 +336,8 @@ Rules:
 - Keep the numbers realistic and measurable (p95 / p99, RPS, error rate, availability, etc.).
 - Answer entirely in the requested language.
 {MARKDOWN_FORMAT_DIRECTIVE}
+
+{"RECORDATORIO FINAL: responde completamente en español." if lang == "es" else "FINAL REMINDER: answer entirely in English."}
 """
 
     result = llm.invoke(prompt)

--- a/back/src/graph/nodes/classifier.py
+++ b/back/src/graph/nodes/classifier.py
@@ -85,8 +85,10 @@ def classifier_node(state: GraphState) -> GraphState:
         intent = "diagram"
 
 
-    # Prioriza el idioma ya detectado al inicio del turno (último mensaje del usuario)
-    lang = state.get("language") or lang_raw
+    # Always use the LLM's fresh classification for the CURRENT message.
+    # Stale state language is intentionally ignored so the language can switch
+    # if the user changes their language between turns.
+    lang = lang_raw or state.get("language") or "es"
 
     # QA primario clasificado junto al intent (misma invocación del classifier).
     qa_from_classifier = normalize_qa(qa_attr)

--- a/back/src/graph/nodes/diagram.py
+++ b/back/src/graph/nodes/diagram.py
@@ -64,13 +64,20 @@ def _sanitize_dot(raw: Any) -> str:
     return normalize_text(txt).strip()
 
 
-def _llm_nl_to_dot(natural_prompt: str, *, level: DiagramLevel, expand: bool = False) -> str:
+def _llm_nl_to_dot(natural_prompt: str, *, level: DiagramLevel, expand: bool = False, lang: str = "es") -> str:
     """Generate DOT code via LLM. Uses expansion prompt when building on a prior level."""
     if expand:
         target_desc = EXPAND_TARGET_MEDIUM if level == DiagramLevel.MEDIUM else EXPAND_TARGET_DETAILED
         system_prompt = DOT_SYSTEM_EXPAND.format(target_description=target_desc)
     else:
         system_prompt = DOT_SYSTEM_OVERVIEW if level == DiagramLevel.OVERVIEW else DOT_SYSTEM
+
+    lang_note = (
+        "Node and edge labels in the DOT graph MUST be written in Spanish (español)."
+        if lang == "es"
+        else "Node and edge labels in the DOT graph MUST be written in English."
+    )
+    system_prompt = f"{system_prompt}\n\n{lang_note}"
     msgs = [SystemMessage(content=normalize_text(system_prompt)), HumanMessage(content=normalize_text(natural_prompt))]
     resp = llm.invoke(msgs)
     raw = getattr(resp, "content", str(resp)) or ""
@@ -178,6 +185,7 @@ def _refresh_ledger_state(state: GraphState, user_id: str, project_id: str | Non
 
 
 def diagram_orchestrator_node(state: GraphState) -> GraphState:
+    _lang = (state.get("language") or "es")
     user_q = normalize_text(state.get("localQuestion") or state.get("userQuestion") or "").strip()
     requested_level = _resolve_diagram_level(state, user_q)
 
@@ -261,7 +269,7 @@ def diagram_orchestrator_node(state: GraphState) -> GraphState:
 
     dot_code = ""
     try:
-        dot_code = _llm_nl_to_dot(full_prompt, level=requested_level, expand=expand_mode)
+        dot_code = _llm_nl_to_dot(full_prompt, level=requested_level, expand=expand_mode, lang=_lang)
     except Exception as exc:
         log.warning("diagram_orchestrator_node: DOT generation failed: %s", exc)
 
@@ -323,7 +331,7 @@ def diagram_orchestrator_node(state: GraphState) -> GraphState:
     # --- Ledger write-back (nonfatal) ---
     _user_id = state.get("user_id_for_prefs") or ""
     _project_id = state.get("project_id")
-    _lang = (state.get("language") or "es")
+    # _lang already set at the top of this function
     if _user_id and diagram_obj.get("ok"):
         _qa = (
             (state.get("ledger_active") or {}).get("asr", {}) or {}

--- a/back/src/graph/nodes/evaluator.py
+++ b/back/src/graph/nodes/evaluator.py
@@ -138,7 +138,16 @@ def evaluator_node(state: GraphState) -> GraphState:
         else:
             book_snips = _book_snippets_for_eval(retriever, concern_hint)
 
-        directive = "Responde en español." if lang=="es" else "Answer in English."
+        if lang == "es":
+            directive = (
+                "IDIOMA OBLIGATORIO: español.\n"
+                "Tu respuesta COMPLETA debe estar en español. No mezcles idiomas."
+            )
+        else:
+            directive = (
+                "MANDATORY LANGUAGE: English.\n"
+                "Your ENTIRE response MUST be in English. Do not mix languages."
+            )
         eval_prompt = f"""{directive}
 You are evaluating a Quality Attribute Scenario (Architecture Significant Requirement).
 
@@ -168,6 +177,8 @@ Provide a tightened ASR using the same QAS structure (Summary, Context, Scenario
 ## References
 List 2-5 short items only if grounded by BOOK_SNIPPETS; otherwise write "None".
 {MARKDOWN_FORMAT_DIRECTIVE}
+
+{"RECORDATORIO FINAL: toda tu respuesta debe estar en español." if lang == "es" else "FINAL REMINDER: your entire response must be in English."}
 """
         eval_prompt = ("DOC-ONLY mode: ON. Reason exclusively from the PROJECT DOCUMENT.\n\n" + eval_prompt) if doc_only else eval_prompt
         result = llm.invoke(eval_prompt)

--- a/back/src/graph/nodes/styles/common.py
+++ b/back/src/graph/nodes/styles/common.py
@@ -209,10 +209,19 @@ def style_node_impl(state: GraphState, qa_override: str | None = None) -> GraphS
     - publica turn_message con name='style_recommender'.
     """
     lang = state.get("language", "es")
-    directive = "Answer in English." if lang == "en" else "Responde en español."
+    if lang == "en":
+        directive = (
+            "MANDATORY LANGUAGE: English.\n"
+            "Your ENTIRE response MUST be in English. Do not mix languages."
+        )
+    else:
+        directive = (
+            "IDIOMA OBLIGATORIO: español.\n"
+            "Tu respuesta COMPLETA debe estar en español. No mezcles idiomas."
+        )
     style_hint = (state.get("user_style_hint") or "").strip()
     if style_hint:
-        directive = f"{directive} {style_hint}"
+        directive = f"{directive}\n{style_hint}"
 
     asr_text = (
         state.get("current_asr")
@@ -282,6 +291,7 @@ You MUST respond with a VALID JSON object ONLY, with NO extra text, in the follo
 }}
 
 Do NOT add comments or any text outside of this JSON object.
+All string values in the JSON (name, impact, rationale) MUST be written in {"English" if lang == "en" else "español"}.
 """
 
     result = llm.invoke(prompt)
@@ -369,6 +379,7 @@ Do NOT add comments or any text outside of this JSON object.
         header = "## Estilos Arquitectónicos Candidatos"
         rec_label = "## Recomendación"
         because = "porque"
+        impact_label = "Impacto"
         followups = [
             f"Explícame tácticas concretas para el ASR usando el estilo recomendado ({chosen_name}).",
             "Compárame más a fondo estos dos estilos para este ASR.",
@@ -377,6 +388,7 @@ Do NOT add comments or any text outside of this JSON object.
         header = "## Candidate Architecture Styles"
         rec_label = "## Recommendation"
         because = "because"
+        impact_label = "Impact"
         followups = [
             f"Explain concrete tactics for the ASR using the recommended style ({chosen_name}).",
             "Compare these two styles in more depth for this ASR.",
@@ -385,9 +397,9 @@ Do NOT add comments or any text outside of this JSON object.
     content = (
         f"{header}\n\n"
         f"### 1. {style1_name}\n\n"
-        f"- **Impact:** {style1_impact}\n\n"
+        f"- **{impact_label}:** {style1_impact}\n\n"
         f"### 2. {style2_name}\n\n"
-        f"- **Impact:** {style2_impact}\n\n"
+        f"- **{impact_label}:** {style2_impact}\n\n"
         f"---\n\n"
         f"{rec_label}\n\n"
         f"**{chosen_name}** {because}:\n\n"

--- a/back/src/graph/nodes/supervisor.py
+++ b/back/src/graph/nodes/supervisor.py
@@ -26,11 +26,26 @@ def _looks_like_eval(text: str) -> bool:
 
 def detect_lang(text: str) -> str:
     t = (text or "").lower()
-    es_hits = sum(w in t for w in ["qué","que","cómo","como","por qué","porque","cuál","cual","hola","táctica","tactica","vista","despliegue"])
-    en_hits = sum(w in t for w in ["what","how","why","which","hello","tactic","view","deployment","component"])
+    es_hits = sum(w in t for w in [
+        "qué","que","cómo","como","por qué","porque","cuál","cual",
+        "hola","táctica","tactica","vista","despliegue","sistema",
+        "para","con","una","uno","dame","quiero","necesito","genera",
+        "muestra","explica","describe","define","crea","hazme","dime",
+        "estilo","tácticas","diagrama","latencia","disponibilidad",
+        "rendimiento","escalabilidad","seguridad","requerimiento",
+        "arquitectura","servicio","microservicio","componente",
+        "ahora","perfecto","vamos","este","ese","eso","mi","mis",
+    ])
+    en_hits = sum(w in t for w in [
+        "what","how","why","which","hello","tactic","view","deployment",
+        "component","please","give","show","explain","create","define",
+        "style","diagram","latency","availability","performance",
+        "scalability","security","requirement","architecture","service",
+        "microservice","now","this","my",
+    ])
     if es_hits > en_hits: return "es"
     if en_hits > es_hits: return "en"
-    return "en"
+    return "es"  # default to Spanish — this app's primary language
 
 def classify_followup(question: str) -> str | None:
     q = (question or "").lower().strip()

--- a/back/src/graph/nodes/tactics/common.py
+++ b/back/src/graph/nodes/tactics/common.py
@@ -279,10 +279,19 @@ def tactics_node_impl(
 ) -> GraphState:
     """Implementación común del nodo de tácticas (ADD 3.0)."""
     lang = state.get("language", "es")
-    directive = "Answer in English." if lang == "en" else "Responde en español."
+    if lang == "en":
+        directive = (
+            "MANDATORY LANGUAGE: English.\n"
+            "Your ENTIRE response MUST be in English. Do not mix languages."
+        )
+    else:
+        directive = (
+            "IDIOMA OBLIGATORIO: español.\n"
+            "Tu respuesta COMPLETA debe estar en español. No mezcles idiomas."
+        )
     style_hint = (state.get("user_style_hint") or "").strip()
     if style_hint:
-        directive = f"{directive} {style_hint}"
+        directive = f"{directive}\n{style_hint}"
     doc_only = bool(state.get("doc_only"))
     ctx_doc = (state.get("doc_context") or "").strip()
     ctx_add = (state.get("add_context") or "").strip()
@@ -418,6 +427,8 @@ Return ONE code fence starting with ```json and ending with ``` that contains ON
 
 Example shape (values are illustrative — adjust to your tactics):
 {TACTICS_JSON_EXAMPLE}
+
+{"RECORDATORIO FINAL: toda tu respuesta (secciones de texto y valores JSON) debe estar en español." if lang == "es" else "FINAL REMINDER: your entire response (text sections and JSON string values) must be in English."}
 """
     resp = llm.invoke(prompt)
     raw = getattr(resp, "content", str(resp)).strip()

--- a/back/src/graph/nodes/unifier.py
+++ b/back/src/graph/nodes/unifier.py
@@ -312,9 +312,18 @@ def unifier_node(state: GraphState) -> GraphState:
         + "\n\n".join(buckets)
     )
 
-    directive = "Responde en español." if lang == "es" else "Answer in English."
+    if lang == "es":
+        directive = (
+            "IDIOMA OBLIGATORIO: español.\n"
+            "Tu respuesta COMPLETA debe estar en español. No mezcles idiomas."
+        )
+    else:
+        directive = (
+            "MANDATORY LANGUAGE: English.\n"
+            "Your ENTIRE response MUST be in English. Do not mix languages."
+        )
     if style_hint:
-        directive = directive + f" {style_hint}"
+        directive = directive + f"\n{style_hint}"
 
     proj_ctx_block = ""
     if proj_ctx:
@@ -344,6 +353,8 @@ RAG_SOURCES:
 
 SOURCE:
 {synthesis_source}
+
+{"RECORDATORIO FINAL: toda tu respuesta debe estar en español." if lang == "es" else "FINAL REMINDER: your entire response must be in English."}
 """
 
     resp = llm.invoke(prompt)

--- a/back/src/ledger/render.py
+++ b/back/src/ledger/render.py
@@ -41,6 +41,15 @@ _T: dict[str, dict[str, str]] = {
         "traces_to":        "traza a ASR",
         "via_style":        "vía estilo",
         "pending_advance":  "Avance pendiente",
+        "superseded_by":    "reemplazado por",
+        # ASR scenario field labels (shown as bullet keys in the dossier)
+        "field_source":           "Fuente",
+        "field_stimulus":         "Estímulo",
+        "field_environment":      "Entorno",
+        "field_artifact":         "Artefacto",
+        "field_response":         "Respuesta",
+        "field_response_measure": "Medida de Respuesta",
+        "field_domain":           "Dominio",
     },
     "en": {
         "title":            "Design Dossier",
@@ -67,6 +76,15 @@ _T: dict[str, dict[str, str]] = {
         "traces_to":        "traces to ASR",
         "via_style":        "via style",
         "pending_advance":  "Pending advance",
+        "superseded_by":    "superseded by",
+        # ASR scenario field labels
+        "field_source":           "Source",
+        "field_stimulus":         "Stimulus",
+        "field_environment":      "Environment",
+        "field_artifact":         "Artifact",
+        "field_response":         "Response",
+        "field_response_measure": "Response Measure",
+        "field_domain":           "Domain",
     },
 }
 
@@ -154,13 +172,15 @@ def render_dossier(
             payload = asr.get("payload") or {}
             lines.append(f"**{T['summary']}:** {_clip_text(payload.get('summary', ''), _MAX_SUMMARY)}")
             lines.append("")
-            for field in ("source", "stimulus", "environment", "artifact", "response", "response_measure"):
+            _field_keys = ("source", "stimulus", "environment", "artifact", "response", "response_measure")
+            for field in _field_keys:
                 val = payload.get(field, "")
                 if val:
-                    lines.append(f"- **{field.replace('_', ' ').title()}:** {val}")
+                    label = T.get(f"field_{field}", field.replace("_", " ").title())
+                    lines.append(f"- **{label}:** {val}")
             domain = payload.get("domain", "")
             if domain:
-                lines.append(f"- **Dominio:** {domain}")
+                lines.append(f"- **{T.get('field_domain', 'Domain')}:** {domain}")
             rationale = asr.get("rationale", "")
             if rationale:
                 lines += ["", f"**{T['rationale']}:** {_clip_text(rationale)}"]
@@ -261,7 +281,9 @@ def render_dossier(
             for d in superseded_list:
                 sup_by = d.get("superseded_by") or "?"
                 date   = (d.get("created_at") or "")[:10]
-                lines.append(f"- {d['kind'].upper()} {d['id']} → reemplazado por {sup_by} el {date}")
+                lines.append(
+                    f"- {d['kind'].upper()} {d['id']} → {T['superseded_by']} {sup_by} {T['on_date']} {date}"
+                )
         else:
             lines.append(none_yet)
         lines.append("")
@@ -278,7 +300,7 @@ def render_dossier(
                 )
                 lines.append(
                     f"- {d['kind'].upper()} **{name}**"
-                    f" (id: {d['id']}, iteración {d['iteration']}) — {status}: \"{reason}\""
+                    f" (id: {d['id']}, {T['iteration'].lower()} {d['iteration']}) — {status}: \"{reason}\""
                 )
         else:
             lines.append(none_yet)

--- a/back/tests/graph/test_asr_p3.py
+++ b/back/tests/graph/test_asr_p3.py
@@ -298,7 +298,8 @@ def test_history_injected_when_dossier_has_superseded():
         asr_node(_state(design_dossier_md=dossier_with_history))
 
     assert len(captured) == 1
-    assert "PRIOR ASR HISTORY" in captured[0]
+    # Spanish default: "HISTORIAL DE ASR PREVIOS"; English: "PRIOR ASR HISTORY"
+    assert ("HISTORIAL DE ASR PREVIOS" in captured[0] or "PRIOR ASR HISTORY" in captured[0])
     assert "01OLDASR" in captured[0]
 
 

--- a/back/tests/ledger/snapshots/asr_only.md
+++ b/back/tests/ledger/snapshots/asr_only.md
@@ -10,12 +10,12 @@ _(ninguna aún)_
 ### ASR  (id: 01FIXTURE000000000ASR00001, QA: latencia, fase: ASR)
 **Resumen:** Sistema de pagos con latencia inferior a 200ms bajo carga normal
 
-- **Source:** usuario final
-- **Stimulus:** solicitud de pago
-- **Environment:** producción bajo carga normal
-- **Artifact:** servicio de pagos
-- **Response:** procesar pago y retornar confirmación
-- **Response Measure:** p95 < 200ms @ 5k RPS
+- **Fuente:** usuario final
+- **Estímulo:** solicitud de pago
+- **Entorno:** producción bajo carga normal
+- **Artefacto:** servicio de pagos
+- **Respuesta:** procesar pago y retornar confirmación
+- **Medida de Respuesta:** p95 < 200ms @ 5k RPS
 - **Dominio:** pagos financieros
 
 **Justificación:** El equipo requiere alta velocidad en transacciones de pago para cumplir el SLA.

--- a/back/tests/ledger/snapshots/asr_style_tactic.md
+++ b/back/tests/ledger/snapshots/asr_style_tactic.md
@@ -10,12 +10,12 @@ _(ninguna aún)_
 ### ASR  (id: 01FIXTURE000000000ASR00001, QA: latencia, fase: ASR)
 **Resumen:** Sistema de pagos con latencia inferior a 200ms bajo carga normal
 
-- **Source:** usuario final
-- **Stimulus:** solicitud de pago
-- **Environment:** producción bajo carga normal
-- **Artifact:** servicio de pagos
-- **Response:** procesar pago y retornar confirmación
-- **Response Measure:** p95 < 200ms @ 5k RPS
+- **Fuente:** usuario final
+- **Estímulo:** solicitud de pago
+- **Entorno:** producción bajo carga normal
+- **Artefacto:** servicio de pagos
+- **Respuesta:** procesar pago y retornar confirmación
+- **Medida de Respuesta:** p95 < 200ms @ 5k RPS
 - **Dominio:** pagos financieros
 
 **Justificación:** SLA de negocio exige respuesta rápida.

--- a/back/tests/ledger/snapshots/with_rejected_orphans.md
+++ b/back/tests/ledger/snapshots/with_rejected_orphans.md
@@ -10,12 +10,12 @@ _(ninguna aún)_
 ### ASR  (id: 01FIXTURE000000000ASR00001, QA: latencia, fase: ASR)
 **Resumen:** Sistema de pagos con latencia inferior a 200ms
 
-- **Source:** usuario final
-- **Stimulus:** solicitud de pago
-- **Environment:** producción
-- **Artifact:** servicio de pagos
-- **Response:** procesar pago
-- **Response Measure:** p95 < 200ms
+- **Fuente:** usuario final
+- **Estímulo:** solicitud de pago
+- **Entorno:** producción
+- **Artefacto:** servicio de pagos
+- **Respuesta:** procesar pago
+- **Medida de Respuesta:** p95 < 200ms
 - **Dominio:** pagos
 
 **Justificación:** SLA de negocio.


### PR DESCRIPTION
Root cause: detect_lang defaulted to "en" for Spanish messages that lacked the small hardcoded keyword set (e.g. "Genera un ASR para un sistema de pagos"), storing "en" in the LangGraph checkpoint. The classifier then permanently preserved it via `state.get("language") or lang_raw`, so every subsequent turn stayed in English regardless of the user's actual language.

Changes:
- supervisor.py: expanded detect_lang Spanish vocabulary (~25 words), changed default from "en" to "es" (app's primary language)
- classifier.py: flipped to `lang_raw or state.get("language")` so LLM per-message detection is authoritative and language can switch
- render.py: localize ASR field labels (Fuente/Estímulo/…), superseded/rejected lines, and "iteración" via _T table instead of hardcoded Spanish or always-English .title()
- asr.py: localize prior_asr_section block (Spanish/English variants), strengthen directive to 2-line IDIOMA OBLIGATORIO block, add end-of-prompt reminder
- styles/common.py: add `impact_label` ("Impacto"/"Impact"), strengthen directive, add end reminder
- tactics/common.py: strengthen directive, add end reminder
- evaluator.py: strengthen directive, add end reminder
- unifier.py: strengthen directive, add end reminder
- diagram.py: pass lang to _llm_nl_to_dot so DOT labels respect language
- test_asr_p3.py: accept Spanish or English history heading
- render snapshots: regenerated with Spanish field labels