### PR TITLE
Feat/intake node

### DIFF
--- a/back/src/graph/nodes/asr.py
+++ b/back/src/graph/nodes/asr.py
@@ -248,6 +248,51 @@ def asr_node(state: GraphState) -> GraphState:
     ).strip()[:2000]
     proj_ctx = (state.get("project_context_text") or "").strip()
 
+    # ── Intake context injection ───────────────────────────────────────────
+    _intake_v1 = (state.get("ledger") or {}).get("project_context", {}).get("intake_v1") or {}
+    if _intake_v1:
+        _INTAKE_LABELS = {
+            "campo_0_requerimiento": ("Requerimiento principal",      "Main requirement"),
+            "campo_1_componentes":   ("Componentes del sistema",      "System components"),
+            "campo_2_fuente":        ("Fuente del estímulo",          "Stimulus source"),
+            "campo_3_estimulo":      ("Estímulo / trigger",           "Stimulus / trigger"),
+            "campo_4_ambientes":     ("Ambientes y métricas",         "Environments and metrics"),
+            "campo_5_prioridad_qa":  ("Prioridad de atributos QA",    "QA attribute priorities"),
+            "campo_6_restricciones": ("Restricciones técnicas",       "Technical constraints"),
+            "campo_7_decisiones":    ("Decisiones de diseño previas", "Prior design decisions"),
+        }
+        label_idx = 1 if lang == "en" else 0
+        lines = []
+        for key, labels in _INTAKE_LABELS.items():
+            val = _intake_v1.get(key, "").strip()
+            if val:
+                lines.append(f"- **{labels[label_idx]}:** {val}")
+        if lines:
+            if lang == "en":
+                intake_context_section = (
+                    f'\n{"=" * 60}\n'
+                    f'INTAKE CONTEXT — ARCHITECT-PROVIDED REQUIREMENTS:\n'
+                    + "\n".join(lines) + "\n"
+                    f'\nIMPORTANT: The ASR MUST be grounded in this context. Use the real\n'
+                    f'requirement, components, source, stimulus, environments and constraints\n'
+                    f'above. Do NOT invent a generic domain.\n'
+                    f'{"=" * 60}\n'
+                )
+            else:
+                intake_context_section = (
+                    f'\n{"=" * 60}\n'
+                    f'CONTEXTO DEL INTAKE — REQUERIMIENTOS PROVISTOS POR EL ARQUITECTO:\n'
+                    + "\n".join(lines) + "\n"
+                    f'\nIMPORTANTE: El ASR DEBE estar fundamentado en este contexto. Usa el\n'
+                    f'requerimiento, componentes, fuente, estímulo, ambientes y restricciones\n'
+                    f'reales de arriba. NO inventes un dominio genérico.\n'
+                    f'{"=" * 60}\n'
+                )
+        else:
+            intake_context_section = ""
+    else:
+        intake_context_section = ""
+
     # ── Dossier history injection (P3) ─────────────────────────────────────
     history_block = _extract_dossier_history(
         (state.get("design_dossier_md") or "").strip()
@@ -295,7 +340,7 @@ IMPORTANT: If a tech stack is listed above, the ASR's Artifact and Response MUST
 those specific technologies. If business rules are listed, the ASR scenario MUST be coherent
 with them. Do NOT use generic placeholders like "the system" when a real stack is provided.
 {"=" * 60}
-{prior_asr_section}
+{intake_context_section}{prior_asr_section}
 Relevant domain or workload (you must stay coherent with this):
 {domain}
 

--- a/back/src/graph/nodes/classifier.py
+++ b/back/src/graph/nodes/classifier.py
@@ -1,8 +1,26 @@
+import re
 from functools import lru_cache
 from src.services.llm_factory import get_chat_model
 from src.graph.state import GraphState, ClassifyOut
 from src.graph.index_resolver import resolve_quality_attribute
 from src.graph.qa_registry import detect_explicit_qa, normalize_qa, supported_qas
+
+# Fast regex-based language detector — used during INTAKE to skip the LLM call
+# while still updating language on every turn.
+_ES_MARKERS = re.compile(
+    r"[áéíóúüñ¿¡]"
+    r"|\b(hola|gracias|cómo|como|qué|que|está|tienes|puedes|"
+    r"necesito|quiero|tengo|los|las|con|para|sí|hay|bien|mal|"
+    r"mi|tu|su|una|ninguna|ningún|"
+    r"el|la|del|al|debe|deben|usuario|usuarios|sistema|"
+    r"por|pero|también|cuando|donde|quien|"
+    r"escalar|procesar|diseñar|implementar|manejar)\b",
+    re.IGNORECASE,
+)
+
+
+def _detect_lang_fast(msg: str) -> str:
+    return "es" if _ES_MARKERS.search(msg) else "en"
 
 llm = get_chat_model(temperature=0.0)
 
@@ -48,10 +66,12 @@ def classifier_node(state: GraphState) -> GraphState:
     "quality_attribute" para que supervisor/router puedan decidir nodos
     específicos por QA (p. ej. style_latency vs style_scalability).
     """
-    # During INTAKE the supervisor will redirect to intake_node regardless of intent.
-    # Skip the LLM call entirely to preserve intent="intake" and avoid spurious QA overrides.
+    # During INTAKE the supervisor routes to intake_node regardless of intent.
+    # Skip the LLM call to preserve intent="intake" and avoid spurious QA overrides,
+    # but still detect language so intake_node responds in the user's language.
     if (state.get("current_phase") or "") == "INTAKE":
-        return {**state}
+        msg = state.get("userQuestion", "") or ""
+        return {**state, "language": _detect_lang_fast(msg)}
 
     msg = state.get("userQuestion", "") or ""
     qa_ids = supported_qas()

--- a/back/src/graph/nodes/classifier.py
+++ b/back/src/graph/nodes/classifier.py
@@ -71,7 +71,13 @@ def classifier_node(state: GraphState) -> GraphState:
     # but still detect language so intake_node responds in the user's language.
     if (state.get("current_phase") or "") == "INTAKE":
         msg = state.get("userQuestion", "") or ""
-        return {**state, "language": _detect_lang_fast(msg)}
+        prior_lang = state.get("language") or "es"
+        detected = _detect_lang_fast(msg)
+        # Only switch to "en" when there is positive English evidence (message long
+        # enough to carry signal). Short/ambiguous messages like "no", "ok", "genera"
+        # must not flip the language the user established earlier in the session.
+        lang = detected if (detected == "es" or len(msg.split()) > 2) else prior_lang
+        return {**state, "language": lang}
 
     msg = state.get("userQuestion", "") or ""
     qa_ids = supported_qas()

--- a/back/src/graph/nodes/classifier.py
+++ b/back/src/graph/nodes/classifier.py
@@ -48,6 +48,11 @@ def classifier_node(state: GraphState) -> GraphState:
     "quality_attribute" para que supervisor/router puedan decidir nodos
     específicos por QA (p. ej. style_latency vs style_scalability).
     """
+    # During INTAKE the supervisor will redirect to intake_node regardless of intent.
+    # Skip the LLM call entirely to preserve intent="intake" and avoid spurious QA overrides.
+    if (state.get("current_phase") or "") == "INTAKE":
+        return {**state}
+
     msg = state.get("userQuestion", "") or ""
     qa_ids = supported_qas()
     qa_opts = qa_ids + ["general"]

--- a/back/src/graph/nodes/intake_node.py
+++ b/back/src/graph/nodes/intake_node.py
@@ -1,9 +1,31 @@
 # -*- coding: utf-8 -*-
+import logging
 import re
+from datetime import datetime, timezone
 
 from src.graph.resources import llm
 from src.graph.state import GraphState
 from src.graph.nodes.intake_validators import INTAKE_SCRIPT, validate_field, reprompt_message
+from src.ledger.store import (
+    transition_phase,
+    append_decision,
+    load_ledger,
+    save_ledger,
+    LedgerValidationError,
+    LedgerConcurrencyError,
+)
+from src.ledger.types import Phase, PhaseTransition
+
+log = logging.getLogger(__name__)
+
+_HAS_ASRS_RE = re.compile(
+    r"\bsí\b|yes\b|tengo\b|ya defin[ií]\b|ya hay\b",
+    re.IGNORECASE,
+)
+_NO_ASRS_RE = re.compile(
+    r"\bno\b|ninguno\b|genera\b|prop[oó]n\b|propone\b|t[uú]\b|usted\b",
+    re.IGNORECASE,
+)
 
 _DIGRESSION_RE = re.compile(
     r"\b(asr|diagrama|diagram|t[aá]cticas|tactics|estilo|style|eval[uú]a|"
@@ -55,14 +77,109 @@ def intake_node(state: GraphState) -> GraphState:
 
     asr_question = _ASR_QUESTION_ES if lang == "es" else _ASR_QUESTION_EN
 
-    # Rama A: intake completo, esperando respuesta sobre ASRs (Phase 4 extenderá esto)
+    # Rama A: intake completo — procesar respuesta del arquitecto sobre ASRs
     if intake_complete:
+        _user_id    = (state.get("user_id_for_prefs") or "").strip()
+        _project_id = (state.get("project_id") or "").strip() or None
+        _ts = datetime.now(timezone.utc).isoformat()
+
+        if _HAS_ASRS_RE.search(uq):
+            # A1 — el arquitecto ya tiene ASRs propios
+            if _user_id:
+                try:
+                    append_decision(_user_id, _project_id, {
+                        "id": "",
+                        "kind": "constraint",
+                        "phase": Phase.INTAKE.value,
+                        "iteration": 0,
+                        "qa": "",
+                        "parents": [],
+                        "payload": {"existing_asrs": [uq], "source": "architect_provided"},
+                        "rationale": "",
+                        "sources": [],
+                        "status": "active",
+                        "parent_status": "ok",
+                        "superseded_by": None,
+                        "rejection_reason": None,
+                        "created_at": "",
+                        "created_by_node": "intake_node",
+                    })
+                    transition_phase(_user_id, _project_id, PhaseTransition(
+                        from_phase="INTAKE",
+                        to_phase="ASR",
+                        iteration=1,
+                        triggered_by="user_request",
+                        user_message=uq,
+                        skipped_phases=[],
+                        timestamp=_ts,
+                    ))
+                except (LedgerValidationError, LedgerConcurrencyError, Exception) as _exc:
+                    log.warning("intake_node: ledger error (nonfatal): %s", _exc)
+
+            _msg_es = (
+                "Perfecto, he registrado tus ASRs. Los analizaré y refinaré si es necesario.\n"
+                "Pasamos a la fase ASR."
+            )
+            _msg_en = (
+                "Got it, I've registered your ASRs. I'll analyze and refine them as needed.\n"
+                "Moving to the ASR phase."
+            )
+            return {
+                **state,
+                "intake_fields": intake_fields,
+                "intake_current_field": 8,
+                "intake_complete": True,
+                "endMessage": _msg_es if lang == "es" else _msg_en,
+                "nextNode": "unifier",
+                "intent": "intake",
+            }
+
+        if _NO_ASRS_RE.search(uq):
+            # A2 — ArchIA propone los ASRs
+            if _user_id:
+                try:
+                    _ledger = load_ledger(_user_id, _project_id)
+                    _ledger["project_context"]["intake_v1"] = intake_fields
+                    save_ledger(_user_id, _ledger, _project_id)
+                    transition_phase(_user_id, _project_id, PhaseTransition(
+                        from_phase="INTAKE",
+                        to_phase="ASR",
+                        iteration=1,
+                        triggered_by="user_request",
+                        user_message=uq,
+                        skipped_phases=[],
+                        timestamp=_ts,
+                    ))
+                except (LedgerValidationError, LedgerConcurrencyError, Exception) as _exc:
+                    log.warning("intake_node: ledger error (nonfatal): %s", _exc)
+
+            _msg_es = "Perfecto. Con el contexto que me has dado voy a proponerte los ASRs."
+            _msg_en = "Perfect. With the context you've provided I'll now propose the ASRs."
+            return {
+                **state,
+                "intake_fields": intake_fields,
+                "intake_current_field": 8,
+                "intake_complete": True,
+                "endMessage": _msg_es if lang == "es" else _msg_en,
+                "nextNode": "asr",
+                "intent": "intake",
+            }
+
+        # A3 — respuesta ambigua: repregunta con más claridad
+        _clarify_es = (
+            "No estoy seguro de entenderte. ¿Ya tienes ASRs definidos que quieras compartir, "
+            "o prefieres que yo los proponga basándome en el contexto que me diste?"
+        )
+        _clarify_en = (
+            "I'm not sure I understood. Do you already have ASRs defined that you'd like to share, "
+            "or would you prefer that I propose them based on the context you provided?"
+        )
         return {
             **state,
             "intake_fields": intake_fields,
-            "intake_current_field": current_index,
+            "intake_current_field": 8,
             "intake_complete": True,
-            "endMessage": asr_question,
+            "endMessage": _clarify_es if lang == "es" else _clarify_en,
             "nextNode": "unifier",
             "intent": "intake",
         }

--- a/back/src/graph/nodes/intake_node.py
+++ b/back/src/graph/nodes/intake_node.py
@@ -168,7 +168,10 @@ async def intake_node(state: GraphState) -> GraphState:
             }
 
         if _NO_ASRS_RE.search(uq):
-            # A2 — ArchIA propone los ASRs
+            # A2 — ArchIA propone los ASRs.
+            # Persists intake_v1 in the ledger, mirrors current_phase="ASR" in state,
+            # and routes to asr_node in this same turn via the conditional intake edge.
+            _updated_ledger = None
             if _user_id:
                 try:
                     _ledger = load_ledger(_user_id, _project_id)
@@ -183,20 +186,25 @@ async def intake_node(state: GraphState) -> GraphState:
                         skipped_phases=[],
                         timestamp=_ts,
                     ))
+                    _updated_ledger = _ledger
                 except (LedgerValidationError, LedgerConcurrencyError, Exception) as _exc:
                     log.warning("intake_node: ledger error (nonfatal): %s", _exc)
 
-            _msg_es = "Perfecto. Con el contexto que me has dado voy a proponerte los ASRs."
-            _msg_en = "Perfect. With the context you've provided I'll now propose the ASRs."
-            return {
+            _a2: dict = {
                 **state,
                 "intake_fields": intake_fields,
                 "intake_current_field": 8,
                 "intake_complete": True,
-                "endMessage": _msg_es if lang == "es" else _msg_en,
+                "current_phase": "ASR",  # mirror ledger transition so supervisor skips INTAKE gate
+                "endMessage": "",         # asr_node will set the real response
                 "nextNode": "asr",
-                "intent": "intake",
+                "intent": "asr",
             }
+            if _updated_ledger is not None:
+                # Provide asr_node with intake_v1 in state so intake context is injected
+                # into the ASR prompt without waiting for the next context_loader reload.
+                _a2["ledger"] = _updated_ledger
+            return _a2
 
         # A3 — respuesta ambigua: repregunta con más claridad
         _clarify_es = (

--- a/back/src/graph/nodes/intake_node.py
+++ b/back/src/graph/nodes/intake_node.py
@@ -27,12 +27,40 @@ _NO_ASRS_RE = re.compile(
     re.IGNORECASE,
 )
 
-_DIGRESSION_RE = re.compile(
-    r"\b(asr|diagrama|diagram|t[aá]cticas|tactics|estilo|style|eval[uú]a|"
-    r"evaluate|analiza|analyze|genera\b|generate|patr[oó]n|pattern|"
-    r"arquitectura|architecture|dise[nñ]a|design)\b",
+# Digression detection: a message is a digression only when the *intent* is to
+# ask or request something off-topic from intake, NOT when architectural terms
+# appear incidentally inside a descriptive answer.
+# Rule: must have BOTH (a) a question or meta-imperative form AND (b) meta-terms.
+_DIGRESSION_TERMS_RE = re.compile(
+    r"\b(asr|diagrama|diagram|t[aá]cticas|tactics|estilo|style|"
+    r"patr[oó]n|patron|pattern|add\b|atam|togaf|"
+    r"eval[uú]a|evaluate|analiza|analyze|genera|generate|"
+    r"dise[nñ]a|disena|design|arquitectura|architecture)\b",
     re.IGNORECASE,
 )
+# Question form: contains "?" or starts with interrogative word
+_DIGRESSION_QUESTION_RE = re.compile(
+    r"[?¿]"
+    r"|^\s*[¿¡]"
+    r"|^\s*(qué|que|cómo|como|cuál|cual|por qué|para qué|"
+    r"what|how|which|why|explain|define|describe|tell me|"
+    r"cuéntame|cuentame|explícame|explicame)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+# Explicit meta-imperative at start of message (request for an off-topic action)
+_DIGRESSION_IMPERATIVE_RE = re.compile(
+    r"^\s*(muéstrame|muestrame|crea|genera|propón|propon|propone|"
+    r"diseña|disena|evalúa|evalua|analiza|show me|create|generate|"
+    r"propose|design|draw|build me|explain|describe)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_digression(uq: str) -> bool:
+    """True only when the message is a question or explicit meta-request, not a descriptive answer."""
+    if not _DIGRESSION_TERMS_RE.search(uq):
+        return False
+    return bool(_DIGRESSION_QUESTION_RE.search(uq)) or bool(_DIGRESSION_IMPERATIVE_RE.search(uq))
 
 _ASR_QUESTION_ES = (
     "Ya tengo toda la información necesaria. "
@@ -198,7 +226,7 @@ def intake_node(state: GraphState) -> GraphState:
 
     # Rama C: primer turno (sin campos previos) — validar o dar bienvenida
     if current_index == 0 and not intake_fields:
-        if _DIGRESSION_RE.search(uq):
+        if _is_digression(uq):
             brief = _llm_digression(uq, lang)
             re_question = INTAKE_SCRIPT[0][f"question_{lang}"]
             sep = "Para continuar necesito que respondas" if lang == "es" else "To continue I need you to answer"
@@ -240,7 +268,7 @@ def intake_node(state: GraphState) -> GraphState:
         }
 
     # Rama D: turno normal (campos 0-7 con respuesta del usuario a validar)
-    if _DIGRESSION_RE.search(uq):
+    if _is_digression(uq):
         brief = _llm_digression(uq, lang)
         re_question = INTAKE_SCRIPT[current_index][f"question_{lang}"]
         sep = "Para continuar necesito que respondas" if lang == "es" else "To continue I need you to answer"

--- a/back/src/graph/nodes/intake_node.py
+++ b/back/src/graph/nodes/intake_node.py
@@ -5,7 +5,12 @@ from datetime import datetime, timezone
 
 from src.graph.resources import llm
 from src.graph.state import GraphState
-from src.graph.nodes.intake_validators import INTAKE_SCRIPT, validate_field, reprompt_message
+from src.graph.nodes.intake_validators import (
+    INTAKE_SCRIPT,
+    validate_field,
+    reprompt_message,
+    validate_field_semantic,
+)
 from src.ledger.store import (
     transition_phase,
     append_decision,
@@ -96,7 +101,7 @@ def _llm_digression(uq: str, lang: str) -> str:
     return str(response.content).strip()
 
 
-def intake_node(state: GraphState) -> GraphState:
+async def intake_node(state: GraphState) -> GraphState:
     uq = (state.get("userQuestion") or "").strip()
     lang = state.get("language") or "es"
     intake_fields = dict(state.get("intake_fields") or {})
@@ -243,6 +248,18 @@ def intake_node(state: GraphState) -> GraphState:
 
         valid, _ = validate_field(0, uq)
         if valid:
+            sem_ok, sem_reason = await validate_field_semantic(0, uq, lang)
+            if not sem_ok:
+                end_msg = f"{sem_reason}\n\n{INTAKE_SCRIPT[0][f'question_{lang}']}"
+                return {
+                    **state,
+                    "intake_fields": intake_fields,
+                    "intake_current_field": 0,
+                    "intake_complete": False,
+                    "endMessage": end_msg,
+                    "nextNode": "unifier",
+                    "intent": "intake",
+                }
             intake_fields[INTAKE_SCRIPT[0]["field"]] = uq
             end_msg = INTAKE_SCRIPT[1][f"question_{lang}"]
             return {
@@ -296,6 +313,19 @@ def intake_node(state: GraphState) -> GraphState:
             "intent": "intake",
         }
 
+    sem_ok, sem_reason = await validate_field_semantic(current_index, uq, lang)
+    if not sem_ok:
+        end_msg = f"{sem_reason}\n\n{INTAKE_SCRIPT[current_index][f'question_{lang}']}"
+        return {
+            **state,
+            "intake_fields": intake_fields,
+            "intake_current_field": current_index,
+            "intake_complete": False,
+            "endMessage": end_msg,
+            "nextNode": "unifier",
+            "intent": "intake",
+        }
+
     # Válido: guardar y avanzar
     intake_fields[INTAKE_SCRIPT[current_index]["field"]] = uq
     new_index = current_index + 1
@@ -324,6 +354,8 @@ def intake_node(state: GraphState) -> GraphState:
 
 
 if __name__ == "__main__":
+    import asyncio
+
     def _base(intake_fields, idx, uq, lang="es"):
         return {
             "userQuestion": uq,
@@ -338,107 +370,110 @@ if __name__ == "__main__":
             "turn_messages": [],
         }
 
-    # Test 1 — turno inicial con saludo → bienvenida + campo 0, no avanza
-    r = intake_node(_base({}, 0, "hola"))
-    assert r["intake_current_field"] == 0, f"esperaba 0, got {r['intake_current_field']}"
-    assert "requerimiento" in r["endMessage"].lower(), "esperaba 'requerimiento' en endMessage"
+    async def _run_tests():
+        # Test 1 — turno inicial con saludo → bienvenida + campo 0, no avanza
+        r = await intake_node(_base({}, 0, "hola"))
+        assert r["intake_current_field"] == 0, f"esperaba 0, got {r['intake_current_field']}"
+        assert "requerimiento" in r["endMessage"].lower(), "esperaba 'requerimiento' en endMessage"
 
-    # Test 2 — campo 0 válido → avanza a campo 1
-    r = intake_node(_base({}, 0, "el microservicio de pagos debe procesar 1000 transacciones/s con latencia <200ms"))
-    assert r["intake_current_field"] == 1, f"esperaba 1, got {r['intake_current_field']}"
-    assert "campo_0_requerimiento" in r["intake_fields"], "campo_0_requerimiento no guardado"
+        # Test 2 — campo 0 válido → avanza a campo 1
+        r = await intake_node(_base({}, 0, "el microservicio de pagos debe procesar 1000 transacciones/s con latencia <200ms"))
+        assert r["intake_current_field"] == 1, f"esperaba 1, got {r['intake_current_field']}"
+        assert "campo_0_requerimiento" in r["intake_fields"], "campo_0_requerimiento no guardado"
 
-    # Test 3 — campo 4 inválido → reprompt sin avanzar
-    fields_0_3 = {INTAKE_SCRIPT[i]["field"]: "valor de prueba" for i in range(4)}
-    r = intake_node(_base(fields_0_3, 4, "funciona bien en producción normalmente"))
-    assert r["intake_current_field"] == 4, f"esperaba 4, got {r['intake_current_field']}"
-    assert any(w in r["endMessage"].lower() for w in ["métrica", "número", "concreto", "rps", "ms"]), \
-        f"esperaba mensaje de métrica, got: {r['endMessage'][:100]}"
+        # Test 3 — campo 4 inválido → reprompt sin avanzar
+        fields_0_3 = {INTAKE_SCRIPT[i]["field"]: "valor de prueba" for i in range(4)}
+        r = await intake_node(_base(fields_0_3, 4, "funciona bien en producción normalmente"))
+        assert r["intake_current_field"] == 4, f"esperaba 4, got {r['intake_current_field']}"
+        assert any(w in r["endMessage"].lower() for w in ["métrica", "número", "concreto", "rps", "ms"]), \
+            f"esperaba mensaje de métrica, got: {r['endMessage'][:100]}"
 
-    # Test 4 — digresión → re-pregunta campo actual (no avanza)
-    r = intake_node(_base({"campo_0_requerimiento": "descripcion"}, 1, "¿qué es el patrón CQRS?"))
-    assert r["intake_current_field"] == 1, f"esperaba 1, got {r['intake_current_field']}"
-    assert "Para continuar" in r["endMessage"] or "To continue" in r["endMessage"], \
-        f"esperaba separador, got: {r['endMessage'][:100]}"
+        # Test 4 — digresión → re-pregunta campo actual (no avanza)
+        r = await intake_node(_base({"campo_0_requerimiento": "descripcion"}, 1, "¿qué es el patrón CQRS?"))
+        assert r["intake_current_field"] == 1, f"esperaba 1, got {r['intake_current_field']}"
+        assert "Para continuar" in r["endMessage"] or "To continue" in r["endMessage"], \
+            f"esperaba separador, got: {r['endMessage'][:100]}"
 
-    # Test 5 — campo 7 válido → intake_complete=True, pregunta de ASRs
-    fields_0_6 = {INTAKE_SCRIPT[i]["field"]: "valor suficientemente largo" for i in range(7)}
-    r = intake_node(_base(fields_0_6, 7, "ninguna restricción previa de diseño arquitectónico"))
-    assert r["intake_complete"] is True, "esperaba intake_complete=True"
-    assert r["intake_current_field"] == 8, f"esperaba 8, got {r['intake_current_field']}"
-    assert "asr" in r["endMessage"].lower() or "ASR" in r["endMessage"], \
-        f"esperaba pregunta de ASRs, got: {r['endMessage'][:100]}"
+        # Test 5 — campo 7 válido → intake_complete=True, pregunta de ASRs
+        fields_0_6 = {INTAKE_SCRIPT[i]["field"]: "valor suficientemente largo" for i in range(7)}
+        r = await intake_node(_base(fields_0_6, 7, "ninguna restricción previa de diseño arquitectónico"))
+        assert r["intake_complete"] is True, "esperaba intake_complete=True"
+        assert r["intake_current_field"] == 8, f"esperaba 8, got {r['intake_current_field']}"
+        assert "asr" in r["endMessage"].lower() or "ASR" in r["endMessage"], \
+            f"esperaba pregunta de ASRs, got: {r['endMessage'][:100]}"
 
-    print("Phase 2 tests ✓")
+        print("Phase 2 tests ✓")
 
-    # ── Smoke test — language="en" ─────────────────────────────────────────
-    # ST-1: invalid first input → welcome + field-0 question in English
-    r = intake_node(_base({}, 0, "hello", "en"))
-    assert r["intake_current_field"] == 0
-    assert "requirement" in r["endMessage"].lower() or "main requirement" in r["endMessage"].lower(), \
-        f"ST-1 expected English welcome, got: {r['endMessage'][:120]}"
-    assert "requerimiento" not in r["endMessage"].lower(), \
-        f"ST-1 Spanish text leaked into EN message: {r['endMessage'][:120]}"
+        # ── Smoke test — language="en" ─────────────────────────────────────────
+        # ST-1: invalid first input → welcome + field-0 question in English
+        r = await intake_node(_base({}, 0, "hello", "en"))
+        assert r["intake_current_field"] == 0
+        assert "requirement" in r["endMessage"].lower() or "main requirement" in r["endMessage"].lower(), \
+            f"ST-1 expected English welcome, got: {r['endMessage'][:120]}"
+        assert "requerimiento" not in r["endMessage"].lower(), \
+            f"ST-1 Spanish text leaked into EN message: {r['endMessage'][:120]}"
 
-    # ST-2: valid field-0 → field-1 question in English
-    # Note: _TECHNICAL_TERMS includes 'api', 'request', 'endpoint', 'throughput' — use those in English inputs
-    r = intake_node(_base({}, 0, "the API gateway must process each request from external endpoints with throughput 500 rps under 200ms", "en"))
-    assert r["intake_current_field"] == 1, \
-        f"ST-2 expected advance to field 1, got {r['intake_current_field']}. msg: {r['endMessage'][:120]}"
-    assert "component" in r["endMessage"].lower(), \
-        f"ST-2 expected English field-1 question, got: {r['endMessage'][:120]}"
+        # ST-2: valid field-0 → field-1 question in English
+        # Note: _TECHNICAL_TERMS includes 'api', 'request', 'endpoint', 'throughput' — use those in English inputs
+        r = await intake_node(_base({}, 0, "the API gateway must process each request from external endpoints with throughput 500 rps under 200ms", "en"))
+        assert r["intake_current_field"] == 1, \
+            f"ST-2 expected advance to field 1, got {r['intake_current_field']}. msg: {r['endMessage'][:120]}"
+        assert "component" in r["endMessage"].lower(), \
+            f"ST-2 expected English field-1 question, got: {r['endMessage'][:120]}"
 
-    # ST-3: invalid field-4 (no metric) → reprompt error + question in English
-    fields_en = {INTAKE_SCRIPT[i]["field"]: "test value for field" for i in range(4)}
-    r = intake_node(_base(fields_en, 4, "the system works fine in production", "en"))
-    assert r["intake_current_field"] == 4
-    assert "metric" in r["endMessage"].lower(), \
-        f"ST-3 expected English reprompt with 'metric', got: {r['endMessage'][:120]}"
-    assert "métrica" not in r["endMessage"].lower(), \
-        f"ST-3 Spanish text leaked into EN reprompt: {r['endMessage'][:120]}"
+        # ST-3: invalid field-4 (no metric) → reprompt error + question in English
+        fields_en = {INTAKE_SCRIPT[i]["field"]: "test value for field" for i in range(4)}
+        r = await intake_node(_base(fields_en, 4, "the system works fine in production", "en"))
+        assert r["intake_current_field"] == 4
+        assert "metric" in r["endMessage"].lower(), \
+            f"ST-3 expected English reprompt with 'metric', got: {r['endMessage'][:120]}"
+        assert "métrica" not in r["endMessage"].lower(), \
+            f"ST-3 Spanish text leaked into EN reprompt: {r['endMessage'][:120]}"
 
-    # ST-4: field-7 valid → ASR question in English
-    fields_en_06 = {INTAKE_SCRIPT[i]["field"]: "sufficient value for the field here" for i in range(7)}
-    r = intake_node(_base(fields_en_06, 7, "no prior architectural constraints", "en"))
-    assert r["intake_complete"] is True
-    assert "asr" in r["endMessage"].lower() or "ASR" in r["endMessage"], \
-        f"ST-4 expected English ASR question, got: {r['endMessage'][:120]}"
-    assert "ya tienes" not in r["endMessage"].lower(), \
-        f"ST-4 Spanish text leaked into EN ASR question: {r['endMessage'][:120]}"
+        # ST-4: field-7 valid → ASR question in English
+        fields_en_06 = {INTAKE_SCRIPT[i]["field"]: "sufficient value for the field here" for i in range(7)}
+        r = await intake_node(_base(fields_en_06, 7, "no prior architectural constraints", "en"))
+        assert r["intake_complete"] is True
+        assert "asr" in r["endMessage"].lower() or "ASR" in r["endMessage"], \
+            f"ST-4 expected English ASR question, got: {r['endMessage'][:120]}"
+        assert "ya tienes" not in r["endMessage"].lower(), \
+            f"ST-4 Spanish text leaked into EN ASR question: {r['endMessage'][:120]}"
 
-    # ST-5: intake_complete=True, "no" answer → A2 branch in English
-    base_complete_en = {
-        **_base({}, 0, "no", "en"),
-        "intake_complete": True,
-        "intake_current_field": 8,
-    }
-    r = intake_node(base_complete_en)
-    assert "propose" in r["endMessage"].lower() or "asr" in r["endMessage"].lower(), \
-        f"ST-5 expected English A2 message, got: {r['endMessage'][:120]}"
-    assert "propondré" not in r["endMessage"].lower() and "perfecto" not in r["endMessage"].lower(), \
-        f"ST-5 Spanish text leaked into EN A2 message: {r['endMessage'][:120]}"
+        # ST-5: intake_complete=True, "no" answer → A2 branch in English
+        base_complete_en = {
+            **_base({}, 0, "no", "en"),
+            "intake_complete": True,
+            "intake_current_field": 8,
+        }
+        r = await intake_node(base_complete_en)
+        assert "propose" in r["endMessage"].lower() or "asr" in r["endMessage"].lower(), \
+            f"ST-5 expected English A2 message, got: {r['endMessage'][:120]}"
+        assert "propondré" not in r["endMessage"].lower() and "perfecto" not in r["endMessage"].lower(), \
+            f"ST-5 Spanish text leaked into EN A2 message: {r['endMessage'][:120]}"
 
-    # ST-6: intake_complete=True, "yes" answer → A1 branch in English
-    base_complete_yes_en = {
-        **_base({}, 0, "yes I already have ASRs", "en"),
-        "intake_complete": True,
-        "intake_current_field": 8,
-    }
-    r = intake_node(base_complete_yes_en)
-    assert "registered" in r["endMessage"].lower() or "asr" in r["endMessage"].lower(), \
-        f"ST-6 expected English A1 message, got: {r['endMessage'][:120]}"
-    assert "registrado" not in r["endMessage"].lower(), \
-        f"ST-6 Spanish text leaked into EN A1 message: {r['endMessage'][:120]}"
+        # ST-6: intake_complete=True, "yes" answer → A1 branch in English
+        base_complete_yes_en = {
+            **_base({}, 0, "yes I already have ASRs", "en"),
+            "intake_complete": True,
+            "intake_current_field": 8,
+        }
+        r = await intake_node(base_complete_yes_en)
+        assert "registered" in r["endMessage"].lower() or "asr" in r["endMessage"].lower(), \
+            f"ST-6 expected English A1 message, got: {r['endMessage'][:120]}"
+        assert "registrado" not in r["endMessage"].lower(), \
+            f"ST-6 Spanish text leaked into EN A1 message: {r['endMessage'][:120]}"
 
-    # ── Smoke test — language="es" still works ────────────────────────────
-    # ST-7: invalid field-4 → reprompt in Spanish
-    r = intake_node(_base(fields_0_3, 4, "funciona bien en producción normalmente"))
-    assert "métrica" in r["endMessage"].lower() or "número" in r["endMessage"].lower(), \
-        f"ST-7 Spanish reprompt broken: {r['endMessage'][:120]}"
+        # ── Smoke test — language="es" still works ────────────────────────────
+        # ST-7: invalid field-4 → reprompt in Spanish
+        r = await intake_node(_base(fields_0_3, 4, "funciona bien en producción normalmente"))
+        assert "métrica" in r["endMessage"].lower() or "número" in r["endMessage"].lower(), \
+            f"ST-7 Spanish reprompt broken: {r['endMessage'][:120]}"
 
-    # ST-8: field-7 valid → ASR question in Spanish
-    r = intake_node(_base(fields_0_6, 7, "ninguna restricción previa de diseño arquitectónico"))
-    assert "ya tienes" in r["endMessage"].lower() or "asr" in r["endMessage"].lower(), \
-        f"ST-8 Spanish ASR question broken: {r['endMessage'][:120]}"
+        # ST-8: field-7 valid → ASR question in Spanish
+        r = await intake_node(_base(fields_0_6, 7, "ninguna restricción previa de diseño arquitectónico"))
+        assert "ya tienes" in r["endMessage"].lower() or "asr" in r["endMessage"].lower(), \
+            f"ST-8 Spanish ASR question broken: {r['endMessage'][:120]}"
 
-    print("Language smoke tests ✓")
+        print("Language smoke tests ✓")
+
+    asyncio.run(_run_tests())

--- a/back/src/graph/nodes/intake_node.py
+++ b/back/src/graph/nodes/intake_node.py
@@ -1,0 +1,227 @@
+# -*- coding: utf-8 -*-
+import re
+
+from src.graph.resources import llm
+from src.graph.state import GraphState
+from src.graph.nodes.intake_validators import INTAKE_SCRIPT, validate_field, reprompt_message
+
+_DIGRESSION_RE = re.compile(
+    r"\b(asr|diagrama|diagram|t[aá]cticas|tactics|estilo|style|eval[uú]a|"
+    r"evaluate|analiza|analyze|genera\b|generate|patr[oó]n|pattern|"
+    r"arquitectura|architecture|dise[nñ]a|design)\b",
+    re.IGNORECASE,
+)
+
+_ASR_QUESTION_ES = (
+    "Ya tengo toda la información necesaria. "
+    "¿Quieres que proponga los ASRs o ya tienes alguno definido?"
+)
+_ASR_QUESTION_EN = (
+    "I have all the information needed. "
+    "Would you like me to propose the ASRs, or do you already have some defined?"
+)
+
+_WELCOME_ES = (
+    "¡Hola! Soy ArchIA. Antes de generar los Atributos de Calidad y Escenarios de Calidad (ASRs) "
+    "necesito conocer bien tu proyecto. Te haré 8 preguntas cortas sobre el contexto del sistema.\n\n"
+    "Empecemos con la primera:"
+)
+_WELCOME_EN = (
+    "Hi! I'm ArchIA. Before generating the Architecture Significant Requirements (ASRs) "
+    "I need to understand your project. I'll ask you 8 short questions about the system context.\n\n"
+    "Let's start with the first one:"
+)
+
+
+def _welcome_message(lang: str) -> str:
+    return _WELCOME_ES if lang == "es" else _WELCOME_EN
+
+
+def _llm_digression(uq: str, lang: str) -> str:
+    if lang == "es":
+        prompt = f"Responde en 1-2 líneas esta pregunta de arquitectura: {uq[:200]}"
+    else:
+        prompt = f"Answer in 1-2 lines this architecture question: {uq[:200]}"
+    response = llm.invoke(prompt)
+    return str(response.content).strip()
+
+
+def intake_node(state: GraphState) -> GraphState:
+    uq = (state.get("userQuestion") or "").strip()
+    lang = state.get("language") or "es"
+    intake_fields = dict(state.get("intake_fields") or {})
+    current_index = state.get("intake_current_field") or 0
+    intake_complete = state.get("intake_complete") or False
+
+    asr_question = _ASR_QUESTION_ES if lang == "es" else _ASR_QUESTION_EN
+
+    # Rama A: intake completo, esperando respuesta sobre ASRs (Phase 4 extenderá esto)
+    if intake_complete:
+        return {
+            **state,
+            "intake_fields": intake_fields,
+            "intake_current_field": current_index,
+            "intake_complete": True,
+            "endMessage": asr_question,
+            "nextNode": "unifier",
+            "intent": "intake",
+        }
+
+    # Rama B: todos los campos validados en este turno
+    if current_index >= 8:
+        return {
+            **state,
+            "intake_fields": intake_fields,
+            "intake_current_field": 8,
+            "intake_complete": True,
+            "endMessage": asr_question,
+            "nextNode": "unifier",
+            "intent": "intake",
+        }
+
+    # Rama C: primer turno (sin campos previos) — validar o dar bienvenida
+    if current_index == 0 and not intake_fields:
+        if _DIGRESSION_RE.search(uq):
+            brief = _llm_digression(uq, lang)
+            re_question = INTAKE_SCRIPT[0][f"question_{lang}"]
+            sep = "Para continuar necesito que respondas" if lang == "es" else "To continue I need you to answer"
+            end_msg = f"{brief}\n\n---\n{sep}: {re_question}"
+            return {
+                **state,
+                "intake_fields": intake_fields,
+                "intake_current_field": 0,
+                "intake_complete": False,
+                "endMessage": end_msg,
+                "nextNode": "unifier",
+                "intent": "intake",
+            }
+
+        valid, _ = validate_field(0, uq)
+        if valid:
+            intake_fields[INTAKE_SCRIPT[0]["field"]] = uq
+            end_msg = INTAKE_SCRIPT[1][f"question_{lang}"]
+            return {
+                **state,
+                "intake_fields": intake_fields,
+                "intake_current_field": 1,
+                "intake_complete": False,
+                "endMessage": end_msg,
+                "nextNode": "unifier",
+                "intent": "intake",
+            }
+
+        # Inválido en primer turno → bienvenida suave, sin mensaje de error
+        end_msg = f"{_welcome_message(lang)}\n\n{INTAKE_SCRIPT[0][f'question_{lang}']}"
+        return {
+            **state,
+            "intake_fields": intake_fields,
+            "intake_current_field": 0,
+            "intake_complete": False,
+            "endMessage": end_msg,
+            "nextNode": "unifier",
+            "intent": "intake",
+        }
+
+    # Rama D: turno normal (campos 0-7 con respuesta del usuario a validar)
+    if _DIGRESSION_RE.search(uq):
+        brief = _llm_digression(uq, lang)
+        re_question = INTAKE_SCRIPT[current_index][f"question_{lang}"]
+        sep = "Para continuar necesito que respondas" if lang == "es" else "To continue I need you to answer"
+        end_msg = f"{brief}\n\n---\n{sep}: {re_question}"
+        return {
+            **state,
+            "intake_fields": intake_fields,
+            "intake_current_field": current_index,
+            "intake_complete": False,
+            "endMessage": end_msg,
+            "nextNode": "unifier",
+            "intent": "intake",
+        }
+
+    valid, _ = validate_field(current_index, uq)
+    if not valid:
+        end_msg = reprompt_message(current_index, lang)
+        return {
+            **state,
+            "intake_fields": intake_fields,
+            "intake_current_field": current_index,
+            "intake_complete": False,
+            "endMessage": end_msg,
+            "nextNode": "unifier",
+            "intent": "intake",
+        }
+
+    # Válido: guardar y avanzar
+    intake_fields[INTAKE_SCRIPT[current_index]["field"]] = uq
+    new_index = current_index + 1
+
+    if new_index >= 8:
+        return {
+            **state,
+            "intake_fields": intake_fields,
+            "intake_current_field": 8,
+            "intake_complete": True,
+            "endMessage": asr_question,
+            "nextNode": "unifier",
+            "intent": "intake",
+        }
+
+    end_msg = INTAKE_SCRIPT[new_index][f"question_{lang}"]
+    return {
+        **state,
+        "intake_fields": intake_fields,
+        "intake_current_field": new_index,
+        "intake_complete": False,
+        "endMessage": end_msg,
+        "nextNode": "unifier",
+        "intent": "intake",
+    }
+
+
+if __name__ == "__main__":
+    def _base(intake_fields, idx, uq, lang="es"):
+        return {
+            "userQuestion": uq,
+            "language": lang,
+            "intake_fields": intake_fields,
+            "intake_current_field": idx,
+            "intake_complete": False,
+            "messages": [],
+            "nextNode": "unifier",
+            "intent": "general",
+            "endMessage": "",
+            "turn_messages": [],
+        }
+
+    # Test 1 — turno inicial con saludo → bienvenida + campo 0, no avanza
+    r = intake_node(_base({}, 0, "hola"))
+    assert r["intake_current_field"] == 0, f"esperaba 0, got {r['intake_current_field']}"
+    assert "requerimiento" in r["endMessage"].lower(), "esperaba 'requerimiento' en endMessage"
+
+    # Test 2 — campo 0 válido → avanza a campo 1
+    r = intake_node(_base({}, 0, "el microservicio de pagos debe procesar 1000 transacciones/s con latencia <200ms"))
+    assert r["intake_current_field"] == 1, f"esperaba 1, got {r['intake_current_field']}"
+    assert "campo_0_requerimiento" in r["intake_fields"], "campo_0_requerimiento no guardado"
+
+    # Test 3 — campo 4 inválido → reprompt sin avanzar
+    fields_0_3 = {INTAKE_SCRIPT[i]["field"]: "valor de prueba" for i in range(4)}
+    r = intake_node(_base(fields_0_3, 4, "funciona bien en producción normalmente"))
+    assert r["intake_current_field"] == 4, f"esperaba 4, got {r['intake_current_field']}"
+    assert any(w in r["endMessage"].lower() for w in ["métrica", "número", "concreto", "rps", "ms"]), \
+        f"esperaba mensaje de métrica, got: {r['endMessage'][:100]}"
+
+    # Test 4 — digresión → re-pregunta campo actual (no avanza)
+    r = intake_node(_base({"campo_0_requerimiento": "descripcion"}, 1, "¿qué es el patrón CQRS?"))
+    assert r["intake_current_field"] == 1, f"esperaba 1, got {r['intake_current_field']}"
+    assert "Para continuar" in r["endMessage"] or "To continue" in r["endMessage"], \
+        f"esperaba separador, got: {r['endMessage'][:100]}"
+
+    # Test 5 — campo 7 válido → intake_complete=True, pregunta de ASRs
+    fields_0_6 = {INTAKE_SCRIPT[i]["field"]: "valor suficientemente largo" for i in range(7)}
+    r = intake_node(_base(fields_0_6, 7, "ninguna restricción previa de diseño arquitectónico"))
+    assert r["intake_complete"] is True, "esperaba intake_complete=True"
+    assert r["intake_current_field"] == 8, f"esperaba 8, got {r['intake_current_field']}"
+    assert "asr" in r["endMessage"].lower() or "ASR" in r["endMessage"], \
+        f"esperaba pregunta de ASRs, got: {r['endMessage'][:100]}"
+
+    print("Phase 2 tests ✓")

--- a/back/src/graph/nodes/intake_node.py
+++ b/back/src/graph/nodes/intake_node.py
@@ -285,7 +285,7 @@ def intake_node(state: GraphState) -> GraphState:
 
     valid, _ = validate_field(current_index, uq)
     if not valid:
-        end_msg = reprompt_message(current_index, lang)
+        end_msg = reprompt_message(current_index, lang, uq)
         return {
             **state,
             "intake_fields": intake_fields,

--- a/back/src/graph/nodes/intake_node.py
+++ b/back/src/graph/nodes/intake_node.py
@@ -370,3 +370,75 @@ if __name__ == "__main__":
         f"esperaba pregunta de ASRs, got: {r['endMessage'][:100]}"
 
     print("Phase 2 tests ✓")
+
+    # ── Smoke test — language="en" ─────────────────────────────────────────
+    # ST-1: invalid first input → welcome + field-0 question in English
+    r = intake_node(_base({}, 0, "hello", "en"))
+    assert r["intake_current_field"] == 0
+    assert "requirement" in r["endMessage"].lower() or "main requirement" in r["endMessage"].lower(), \
+        f"ST-1 expected English welcome, got: {r['endMessage'][:120]}"
+    assert "requerimiento" not in r["endMessage"].lower(), \
+        f"ST-1 Spanish text leaked into EN message: {r['endMessage'][:120]}"
+
+    # ST-2: valid field-0 → field-1 question in English
+    # Note: _TECHNICAL_TERMS includes 'api', 'request', 'endpoint', 'throughput' — use those in English inputs
+    r = intake_node(_base({}, 0, "the API gateway must process each request from external endpoints with throughput 500 rps under 200ms", "en"))
+    assert r["intake_current_field"] == 1, \
+        f"ST-2 expected advance to field 1, got {r['intake_current_field']}. msg: {r['endMessage'][:120]}"
+    assert "component" in r["endMessage"].lower(), \
+        f"ST-2 expected English field-1 question, got: {r['endMessage'][:120]}"
+
+    # ST-3: invalid field-4 (no metric) → reprompt error + question in English
+    fields_en = {INTAKE_SCRIPT[i]["field"]: "test value for field" for i in range(4)}
+    r = intake_node(_base(fields_en, 4, "the system works fine in production", "en"))
+    assert r["intake_current_field"] == 4
+    assert "metric" in r["endMessage"].lower(), \
+        f"ST-3 expected English reprompt with 'metric', got: {r['endMessage'][:120]}"
+    assert "métrica" not in r["endMessage"].lower(), \
+        f"ST-3 Spanish text leaked into EN reprompt: {r['endMessage'][:120]}"
+
+    # ST-4: field-7 valid → ASR question in English
+    fields_en_06 = {INTAKE_SCRIPT[i]["field"]: "sufficient value for the field here" for i in range(7)}
+    r = intake_node(_base(fields_en_06, 7, "no prior architectural constraints", "en"))
+    assert r["intake_complete"] is True
+    assert "asr" in r["endMessage"].lower() or "ASR" in r["endMessage"], \
+        f"ST-4 expected English ASR question, got: {r['endMessage'][:120]}"
+    assert "ya tienes" not in r["endMessage"].lower(), \
+        f"ST-4 Spanish text leaked into EN ASR question: {r['endMessage'][:120]}"
+
+    # ST-5: intake_complete=True, "no" answer → A2 branch in English
+    base_complete_en = {
+        **_base({}, 0, "no", "en"),
+        "intake_complete": True,
+        "intake_current_field": 8,
+    }
+    r = intake_node(base_complete_en)
+    assert "propose" in r["endMessage"].lower() or "asr" in r["endMessage"].lower(), \
+        f"ST-5 expected English A2 message, got: {r['endMessage'][:120]}"
+    assert "propondré" not in r["endMessage"].lower() and "perfecto" not in r["endMessage"].lower(), \
+        f"ST-5 Spanish text leaked into EN A2 message: {r['endMessage'][:120]}"
+
+    # ST-6: intake_complete=True, "yes" answer → A1 branch in English
+    base_complete_yes_en = {
+        **_base({}, 0, "yes I already have ASRs", "en"),
+        "intake_complete": True,
+        "intake_current_field": 8,
+    }
+    r = intake_node(base_complete_yes_en)
+    assert "registered" in r["endMessage"].lower() or "asr" in r["endMessage"].lower(), \
+        f"ST-6 expected English A1 message, got: {r['endMessage'][:120]}"
+    assert "registrado" not in r["endMessage"].lower(), \
+        f"ST-6 Spanish text leaked into EN A1 message: {r['endMessage'][:120]}"
+
+    # ── Smoke test — language="es" still works ────────────────────────────
+    # ST-7: invalid field-4 → reprompt in Spanish
+    r = intake_node(_base(fields_0_3, 4, "funciona bien en producción normalmente"))
+    assert "métrica" in r["endMessage"].lower() or "número" in r["endMessage"].lower(), \
+        f"ST-7 Spanish reprompt broken: {r['endMessage'][:120]}"
+
+    # ST-8: field-7 valid → ASR question in Spanish
+    r = intake_node(_base(fields_0_6, 7, "ninguna restricción previa de diseño arquitectónico"))
+    assert "ya tienes" in r["endMessage"].lower() or "asr" in r["endMessage"].lower(), \
+        f"ST-8 Spanish ASR question broken: {r['endMessage'][:120]}"
+
+    print("Language smoke tests ✓")

--- a/back/src/graph/nodes/intake_validators.py
+++ b/back/src/graph/nodes/intake_validators.py
@@ -118,8 +118,44 @@ def validate_field(index: int, value: str) -> Tuple[bool, str]:
     return (True, "")
 
 
+_REPROMPT_ERRORS: dict[int, dict[str, str]] = {
+    0: {
+        "es": "La respuesta es demasiado corta. Necesita al menos 8 palabras con vocabulario técnico concreto (servicio, módulo, API, componente, etc.).",
+        "en": "Answer too short. Need at least 8 words with concrete technical vocabulary (service, module, API, component, etc.).",
+    },
+    1: {
+        "es": "La respuesta es demasiado corta. Necesita al menos 8 palabras con vocabulario técnico concreto (servicio, módulo, API, componente, etc.).",
+        "en": "Answer too short. Need at least 8 words with concrete technical vocabulary (service, module, API, component, etc.).",
+    },
+    2: {
+        "es": "No se identificó la fuente del estímulo. Indica si proviene de: usuario, sistema externo, evento interno, tiempo/timer o schedule.",
+        "en": "Stimulus source not identified. Indicate if it comes from: user, external system, internal event, time/timer or schedule.",
+    },
+    3: {
+        "es": "La respuesta es demasiado corta. Necesita al menos 8 palabras con vocabulario técnico concreto (servicio, módulo, API, componente, etc.).",
+        "en": "Answer too short. Need at least 8 words with concrete technical vocabulary (service, module, API, component, etc.).",
+    },
+    4: {
+        "es": "No se encontró ninguna métrica concreta. Incluye números, comparaciones o unidades como: <200ms, 500rps, 99.9%, p95, SLA, SLO, TPS.",
+        "en": "No concrete metric found. Include numbers, comparisons or units such as: <200ms, 500rps, 99.9%, p95, SLA, SLO, TPS.",
+    },
+    5: {
+        "es": "No se encontró ninguna métrica concreta. Incluye números, comparaciones o unidades como: <200ms, 500rps, 99.9%, p95, SLA, SLO, TPS.",
+        "en": "No concrete metric found. Include numbers, comparisons or units such as: <200ms, 500rps, 99.9%, p95, SLA, SLO, TPS.",
+    },
+    6: {
+        "es": "La respuesta es demasiado corta. Describe las restricciones/decisiones previas, o escribe 'ninguna' / 'none' / 'n/a' si no aplica.",
+        "en": "Answer too short. Describe the constraints/prior decisions, or write 'none' / 'n/a' if not applicable.",
+    },
+    7: {
+        "es": "La respuesta es demasiado corta. Describe las restricciones/decisiones previas, o escribe 'ninguna' / 'none' / 'n/a' si no aplica.",
+        "en": "Answer too short. Describe the constraints/prior decisions, or write 'none' / 'n/a' if not applicable.",
+    },
+}
+
+
 def reprompt_message(index: int, lang: str) -> str:
-    _, error_msg = validate_field(index, "")
+    error_msg = _REPROMPT_ERRORS[index][lang if lang in ("es", "en") else "es"]
     key = "question_es" if lang == "es" else "question_en"
     question = INTAKE_SCRIPT[index][key]
     return f"{error_msg}\n\n{question}"

--- a/back/src/graph/nodes/intake_validators.py
+++ b/back/src/graph/nodes/intake_validators.py
@@ -24,6 +24,32 @@ _NEGATION_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+_ALPHA_RE = re.compile(r'\b[a-záéíóúüñ]{3,}\b', re.IGNORECASE)
+
+
+def _content_tokens(text: str) -> set:
+    return {t.lower() for t in _ALPHA_RE.findall(text)}
+
+
+def _is_copy_paste(index: int, value: str) -> bool:
+    """True when >60 % of the question's content tokens appear in value.
+
+    Uses the question as reference so that valid answers containing question
+    vocabulary (e.g. 'sobrecarga', 'mantenimiento') are not falsely flagged.
+    """
+    value_tokens = _content_tokens(value)
+    if len(value_tokens) < 4:
+        return False
+    for lang in ("es", "en"):
+        q_tokens = _content_tokens(INTAKE_SCRIPT[index][f"question_{lang}"])
+        if not q_tokens:
+            continue
+        common = value_tokens & q_tokens
+        if len(common) / len(q_tokens) > 0.60:
+            return True
+    return False
+
+
 INTAKE_SCRIPT = [
     {
         "field": "campo_0_requerimiento",
@@ -76,7 +102,17 @@ INTAKE_SCRIPT = [
 ]
 
 
+_COPY_PASTE_ERRORS: dict[str, str] = {
+    "es": "Parece que pegaste la pregunta como respuesta. Por favor describe tu sistema con tu información específica.",
+    "en": "It looks like you copied the question as your answer. Please describe your system with your specific information.",
+}
+
+
 def validate_field(index: int, value: str) -> Tuple[bool, str]:
+    # Pre-check: reject copy-pasted question text before any other rule.
+    if _is_copy_paste(index, value):
+        return (False, "copy_paste")
+
     if index in (0, 1, 3):
         tokens = value.split()
         if len(tokens) < 8:
@@ -154,9 +190,13 @@ _REPROMPT_ERRORS: dict[int, dict[str, str]] = {
 }
 
 
-def reprompt_message(index: int, lang: str) -> str:
-    error_msg = _REPROMPT_ERRORS[index][lang if lang in ("es", "en") else "es"]
-    key = "question_es" if lang == "es" else "question_en"
+def reprompt_message(index: int, lang: str, value: str = "") -> str:
+    _lang = lang if lang in ("es", "en") else "es"
+    if value and _is_copy_paste(index, value):
+        error_msg = _COPY_PASTE_ERRORS[_lang]
+    else:
+        error_msg = _REPROMPT_ERRORS[index][_lang]
+    key = "question_es" if _lang == "es" else "question_en"
     question = INTAKE_SCRIPT[index][key]
     return f"{error_msg}\n\n{question}"
 
@@ -179,5 +219,26 @@ if __name__ == "__main__":
 
     # Caso 5 — campo 0 con vocabulario técnico suficiente
     assert validate_field(0, "el microservicio de pagos debe procesar transacciones en menos de 300ms") == (True, "")
+
+    # Caso 6 — campo 4: pregunta pegada como respuesta → rechazado
+    ok, reason = validate_field(
+        4,
+        "¿En qué ambientes o escenarios debe operar el sistema? "
+        "Incluye métricas concretas: carga normal, sobrecarga, mantenimiento (ej: p95<200ms, 500rps).",
+    )
+    assert ok is False, "campo 4 copy-paste debería ser rechazado"
+    assert reason == "copy_paste", f"esperaba reason='copy_paste', got '{reason}'"
+
+    # Caso 7 — campo 4 válido con vocabulario de la pregunta (no es copy-paste)
+    assert validate_field(4, "carga normal: p95<200ms; sobrecarga: 500rps; mantenimiento: 2h domingos") == (True, ""), \
+        "respuesta válida con términos de la pregunta fue rechazada incorrectamente"
+
+    # Caso 8 — reprompt_message con copy-paste muestra mensaje específico (es)
+    msg = reprompt_message(4, "es", "¿En qué ambientes o escenarios debe operar el sistema? Incluye métricas concretas: carga normal, sobrecarga, mantenimiento (ej: p95<200ms, 500rps).")
+    assert "pegaste" in msg.lower(), f"esperaba mensaje de copy-paste en es, got: {msg[:100]}"
+
+    # Caso 9 — reprompt_message sin copy-paste muestra mensaje genérico
+    msg = reprompt_message(4, "es", "el sistema funciona bien en producción")
+    assert "métrica" in msg.lower(), f"esperaba mensaje genérico de métrica, got: {msg[:100]}"
 
     print("Todos los casos pasaron ✓")

--- a/back/src/graph/nodes/intake_validators.py
+++ b/back/src/graph/nodes/intake_validators.py
@@ -1,5 +1,8 @@
+import logging
 import re
-from typing import Tuple
+from typing import Tuple, TypedDict
+
+log = logging.getLogger(__name__)
 
 _TECHNICAL_TERMS = re.compile(
     r"\b(módulo|servicio|api|componente|sistema|request|evento|endpoint|"
@@ -201,6 +204,77 @@ def reprompt_message(index: int, lang: str, value: str = "") -> str:
     return f"{error_msg}\n\n{question}"
 
 
+# ── Semantic validation (LLM second layer) ───────────────────────────────────
+
+class _SemanticOut(TypedDict):
+    valid: bool
+    reason: str
+
+
+_FIELD_SEMANTIC_DESCRIPTIONS: dict[int, str] = {
+    0: "main system requirement: objective, involved components, and quality expectations",
+    1: "main system components: services, modules, APIs, databases, or other relevant elements",
+    2: "stimulus source: who or what triggers the system (user, external system, internal event, timer/schedule)",
+    3: "stimulus or trigger: the specific event that activates system behavior",
+    4: "operating environments with concrete metrics: normal load, overload, maintenance (e.g., p95<200ms, 500rps)",
+    5: "quality attribute priorities with concrete numeric values: availability %, latency ms, throughput rps",
+    6: "technical constraints: programming language, infrastructure, budget, regulations — or explicit negation",
+    7: "prior design decisions: patterns, technologies, existing integrations — or explicit negation",
+}
+
+# v1 — fixed prompt; bump version string before changing wording
+_SEMANTIC_PROMPT_V1 = """\
+You are a strict validator for an architecture intake interview.
+Decide only whether the answer below contains real, specific information about the user's own system.
+Do NOT evaluate grammar, writing style, or technical accuracy.
+
+Field {index} — {field_description}
+
+User's answer: "{value}"
+
+Reject (valid=false) if ANY of the following apply:
+- The answer is a copy or near-paraphrase of the question with no original content about the user's system.
+- The answer is entirely generic and could apply to any system (no concrete specifics about THIS system).
+- The answer only names the expected category without any detail (e.g., just "usuario" for a stimulus-source field).
+
+Accept (valid=true) if:
+- The answer contains at least one concrete detail specific to the user's actual system.
+
+When rejecting, write reason as a single short sentence in {lang}. When accepting, set reason to empty string.\
+"""
+
+
+async def validate_field_semantic(index: int, value: str, lang: str) -> Tuple[bool, str]:
+    """LLM-based semantic validation. Call only after validate_field() returns True.
+
+    Fail-open: returns (True, "") if the LLM call fails so infra errors never block the user.
+    """
+    from src.graph.resources import llm  # lazy import — avoids circular deps at module load
+
+    _lang = lang if lang in ("es", "en") else "es"
+    field_desc = _FIELD_SEMANTIC_DESCRIPTIONS.get(index, f"field {index}")
+    prompt = _SEMANTIC_PROMPT_V1.format(
+        index=index,
+        field_description=field_desc,
+        value=value[:500],
+        lang=_lang,
+    )
+    try:
+        out = await llm.with_structured_output(_SemanticOut).ainvoke(prompt)
+        valid = bool(out.get("valid", True))
+        reason = str(out.get("reason") or "").strip()
+        if not valid and not reason:
+            reason = (
+                "La respuesta no contiene información específica sobre tu sistema."
+                if _lang == "es"
+                else "The answer does not contain specific information about your system."
+            )
+        return (valid, reason)
+    except Exception as exc:
+        log.warning("validate_field_semantic: LLM call failed (fail-open): %s", exc)
+        return (True, "")
+
+
 if __name__ == "__main__":
     # Caso 1 — campo 4 válido (métricas concretas)
     assert validate_field(4, "normal: p95<200ms; sobrecarga: 500rps; mantenimiento: 2h los domingos") == (True, "")
@@ -242,3 +316,22 @@ if __name__ == "__main__":
     assert "métrica" in msg.lower(), f"esperaba mensaje genérico de métrica, got: {msg[:100]}"
 
     print("Todos los casos pasaron ✓")
+
+    # ── Semantic validation (integration — requires LLM) ─────────────────────
+    import asyncio
+
+    # Caso 10 — campo 4 con métricas reales → pasa semántica
+    sem_ok, sem_reason = asyncio.run(
+        validate_field_semantic(
+            4, "normal: 300rps p95<200ms, sobrecarga: 1500rps, mantenimiento domingos 2am", "es"
+        )
+    )
+    assert sem_ok is True, f"campo 4 con métricas reales debería pasar semántica, got reason: {sem_reason}"
+
+    # Caso 11 — campo 2 con "usuario" solo pasa determinista pero falla semántica
+    # (la categoría está presente pero no describe nada del sistema real)
+    sem_ok, sem_reason = asyncio.run(validate_field_semantic(2, "usuario", "es"))
+    assert sem_ok is False, f"'usuario' solo debería fallar semántica, got sem_ok={sem_ok}"
+    assert sem_reason, "esperaba razón de rechazo en español"
+
+    print("Semantic validation tests ✓")

--- a/back/src/graph/nodes/intake_validators.py
+++ b/back/src/graph/nodes/intake_validators.py
@@ -1,0 +1,147 @@
+import re
+from typing import Tuple
+
+_TECHNICAL_TERMS = re.compile(
+    r"\b(módulo|servicio|api|componente|sistema|request|evento|endpoint|"
+    r"base de datos|microservicio|caché|cola|latencia|throughput|"
+    r"concurrencia|usuario|cliente|servidor)\b",
+    re.IGNORECASE,
+)
+
+_SOURCE_CATEGORIES = re.compile(
+    r"\b(usuario|user|sistema externo|external system|"
+    r"evento interno|internal event|tiempo|time|timer|schedule)\b",
+    re.IGNORECASE,
+)
+
+_METRIC_PATTERN = re.compile(
+    r"\d+|[<>]=?|%\b|ms\b|rps\b|tps\b|sla\b|slo\b",
+    re.IGNORECASE,
+)
+
+_NEGATION_PATTERN = re.compile(
+    r"\b(ninguna|none|n/a|no hay|sin restricciones)\b",
+    re.IGNORECASE,
+)
+
+INTAKE_SCRIPT = [
+    {
+        "field": "campo_0_requerimiento",
+        "question_es": "¿Cuál es el requerimiento principal del sistema que deseas diseñar? Describe el objetivo principal, los componentes involucrados y las expectativas de calidad.",
+        "question_en": "What is the main requirement of the system you want to design? Describe the main goal, the components involved, and quality expectations.",
+        "rule": "len(tokens) >= 8 AND at least one technical term",
+    },
+    {
+        "field": "campo_1_componentes",
+        "question_es": "¿Cuáles son los componentes principales del sistema? Menciona servicios, módulos, APIs, bases de datos u otros elementos relevantes.",
+        "question_en": "What are the main components of the system? Mention services, modules, APIs, databases, or other relevant elements.",
+        "rule": "len(tokens) >= 8 AND at least one technical term",
+    },
+    {
+        "field": "campo_2_fuente",
+        "question_es": "¿Cuál es la fuente del estímulo? Por ejemplo: usuario, sistema externo, evento interno, tiempo/timer.",
+        "question_en": "What is the source of the stimulus? For example: user, external system, internal event, time/timer.",
+        "rule": "_SOURCE_CATEGORIES match",
+    },
+    {
+        "field": "campo_3_estimulo",
+        "question_es": "¿Cuál es el estímulo o trigger que activa el comportamiento del sistema? Describe el evento específico que dispara la respuesta.",
+        "question_en": "What is the stimulus or trigger that activates system behavior? Describe the specific event that triggers the response.",
+        "rule": "len(tokens) >= 8 AND at least one technical term",
+    },
+    {
+        "field": "campo_4_ambientes",
+        "question_es": "¿En qué ambientes o escenarios debe operar el sistema? Incluye métricas concretas: carga normal, sobrecarga, mantenimiento (ej: p95<200ms, 500rps).",
+        "question_en": "In what environments or scenarios must the system operate? Include concrete metrics: normal load, overload, maintenance (e.g., p95<200ms, 500rps).",
+        "rule": "_METRIC_PATTERN match",
+    },
+    {
+        "field": "campo_5_prioridad_qa",
+        "question_es": "¿Cuál es la prioridad de los atributos de calidad (QA)? Indica niveles o valores concretos: disponibilidad 99.9%, latencia <100ms, throughput 1000rps.",
+        "question_en": "What is the priority of quality attributes (QA)? Provide concrete values: availability 99.9%, latency <100ms, throughput 1000rps.",
+        "rule": "_METRIC_PATTERN match",
+    },
+    {
+        "field": "campo_6_restricciones",
+        "question_es": "¿Cuáles son las restricciones técnicas del proyecto? Por ejemplo: lenguaje de programación, infraestructura, presupuesto, regulaciones. Escribe 'ninguna' si no hay restricciones.",
+        "question_en": "What are the technical constraints of the project? For example: programming language, infrastructure, budget, regulations. Write 'none' if there are no constraints.",
+        "rule": "_NEGATION_PATTERN OR len(value.strip()) >= 10",
+    },
+    {
+        "field": "campo_7_decisiones",
+        "question_es": "¿Existen decisiones de diseño previas que debamos respetar? Por ejemplo: patrones arquitectónicos ya definidos, tecnologías elegidas, integraciones existentes. Escribe 'ninguna' si no hay.",
+        "question_en": "Are there prior design decisions that must be respected? For example: already defined architectural patterns, chosen technologies, existing integrations. Write 'none' if there are none.",
+        "rule": "_NEGATION_PATTERN OR len(value.strip()) >= 10",
+    },
+]
+
+
+def validate_field(index: int, value: str) -> Tuple[bool, str]:
+    if index in (0, 1, 3):
+        tokens = value.split()
+        if len(tokens) < 8:
+            return (
+                False,
+                "La respuesta es demasiado corta. Necesita al menos 8 palabras con vocabulario técnico concreto (servicio, módulo, API, componente, etc.).",
+            )
+        if not _TECHNICAL_TERMS.search(value):
+            return (
+                False,
+                "No se detectó vocabulario técnico. Menciona al menos un término como: servicio, módulo, API, componente, sistema, endpoint, microservicio, etc.",
+            )
+        return (True, "")
+
+    if index == 2:
+        if not _SOURCE_CATEGORIES.search(value):
+            return (
+                False,
+                "No se identificó la fuente del estímulo. Indica si proviene de: usuario, sistema externo, evento interno, tiempo/timer o schedule.",
+            )
+        return (True, "")
+
+    if index in (4, 5):
+        if not _METRIC_PATTERN.search(value):
+            return (
+                False,
+                "No se encontró ninguna métrica concreta. Incluye números, comparaciones o unidades como: <200ms, 500rps, 99.9%, p95, SLA, SLO, TPS.",
+            )
+        return (True, "")
+
+    if index in (6, 7):
+        if _NEGATION_PATTERN.search(value) or len(value.strip()) >= 10:
+            return (True, "")
+        return (
+            False,
+            "La respuesta es demasiado corta. Describe las restricciones/decisiones previas, o escribe 'ninguna' / 'none' / 'n/a' si no aplica.",
+        )
+
+    return (True, "")
+
+
+def reprompt_message(index: int, lang: str) -> str:
+    _, error_msg = validate_field(index, "")
+    key = "question_es" if lang == "es" else "question_en"
+    question = INTAKE_SCRIPT[index][key]
+    return f"{error_msg}\n\n{question}"
+
+
+if __name__ == "__main__":
+    # Caso 1 — campo 4 válido (métricas concretas)
+    assert validate_field(4, "normal: p95<200ms; sobrecarga: 500rps; mantenimiento: 2h los domingos") == (True, "")
+
+    # Caso 2 — campo 4 inválido (sin números ni comparaciones)
+    ok, msg = validate_field(4, "el sistema funciona bien en producción normalmente")
+    assert ok is False
+    assert "métrica" in msg.lower() or "número" in msg.lower() or "concreto" in msg.lower()
+
+    # Caso 3 — campo 2 inválido (sin categoría válida)
+    ok, msg = validate_field(2, "cuando hay mucha carga en el servidor")
+    assert ok is False
+
+    # Caso 4 — campo 6 con negación explícita
+    assert validate_field(6, "ninguna") == (True, "")
+
+    # Caso 5 — campo 0 con vocabulario técnico suficiente
+    assert validate_field(0, "el microservicio de pagos debe procesar transacciones en menos de 300ms") == (True, "")
+
+    print("Todos los casos pasaron ✓")

--- a/back/src/graph/nodes/supervisor.py
+++ b/back/src/graph/nodes/supervisor.py
@@ -167,6 +167,9 @@ Outputs: ['investigator','diagram_agent','evaluator','asr','unifier'].
 def supervisor_node(state: GraphState):
     uq = (state.get("userQuestion") or "")
 
+    if (state.get("current_phase") or "") == "INTAKE":
+        return {**state, "nextNode": "intake", "localQuestion": ""}
+
     # si ya hay un SVG listo en este turno, vamos directo al unifier
     d = state.get("diagram") or {}
     if d.get("ok") and d.get("svg_b64"):

--- a/back/src/graph/nodes/supervisor.py
+++ b/back/src/graph/nodes/supervisor.py
@@ -167,6 +167,11 @@ Outputs: ['investigator','diagram_agent','evaluator','asr','unifier'].
 def supervisor_node(state: GraphState):
     uq = (state.get("userQuestion") or "")
 
+    log.info(
+        "supervisor: current_phase=%r intent=%r nextNode=%r",
+        state.get("current_phase"), state.get("intent"), state.get("nextNode"),
+    )
+
     if (state.get("current_phase") or "") == "INTAKE":
         return {**state, "nextNode": "intake", "localQuestion": ""}
 

--- a/back/src/graph/nodes/unifier.py
+++ b/back/src/graph/nodes/unifier.py
@@ -169,7 +169,10 @@ def unifier_node(state: GraphState) -> GraphState:
         state["suggestions"] = tips
         return {**state, "endMessage": end_text, "intent": "diagram"}
 
-    # ðŸ”´ Caso especial para ESTILOS
+    if intent == "intake":
+        return {**state, "endMessage": state.get("endMessage") or ""}
+
+    # 🔴 Caso especial para ESTILOS
     if intent == "style":
         style_txt = (
             _last_ai_by(state, "style_recommender")
@@ -225,7 +228,7 @@ def unifier_node(state: GraphState) -> GraphState:
         ]
         return {**state, "endMessage": end_text}
 
-    # ðŸ”´ Caso especial para ASR
+    # ðŸ"´ Caso especial para ASR
     if intent == "asr" or intent == "ASR":
         raw_asr = (
             _last_ai_by(state, "asr_recommender")
@@ -259,7 +262,7 @@ def unifier_node(state: GraphState) -> GraphState:
         state["suggestions"] = followups
         return {**state, "endMessage": end_text}
 
-    # ðŸ”´ Caso especial: saludo / smalltalk
+    # ðŸ"´ Caso especial: saludo / smalltalk
     if intent in ("greeting", "smalltalk"):
         if lang == "es":
             hello = "## Bienvenido a ArchIA\n\n¡Hola! ¿Sobre qué tema de arquitectura quieres profundizar?"

--- a/back/src/graph/state.py
+++ b/back/src/graph/state.py
@@ -127,6 +127,7 @@ class GraphState(TypedDict):
         "investigator", "evaluator", "diagram_agent",
         "tactics", "asr", "style", "unifier",
         "style_tactics_parallel",  # transient: emitido por supervisor, consumido por router
+        "intake",
     ]
 
     # planificación multi-intent por turno
@@ -157,7 +158,7 @@ class GraphState(TypedDict):
 
     # control de idioma/intención/forcing RAG
     language: Literal["en","es"]
-    intent: Literal["general","greeting","smalltalk","architecture","diagram","asr","tactics","style"]
+    intent: Literal["general","greeting","smalltalk","architecture","diagram","asr","tactics","style","intake"]
     force_rag: bool
     resolved_index: str  # Índice QA resuelto en classifier (e.g., "escalabilidad", "latencia", "general")
 
@@ -195,6 +196,11 @@ class GraphState(TypedDict):
     ledger_dossier_compact: str   # render_dossier_compact(ledger, lang); "" before load
     ledger_phase_prompt: str      # render_phase_prompt(ledger, lang); "" before load
     ledger_pending_advance: dict  # mirror of ledger["pending_advance"]; {} when None
+
+    # ── Intake phase ─────────────────────────────────────────────────────────
+    intake_fields: dict          # campos recolectados del guión de 8 preguntas
+    intake_current_field: int    # índice activo 0–8 (8 = esperando respuesta de ASRs)
+    intake_complete: bool        # True cuando los 8 campos han sido validados
 
 class AgentState(TypedDict):
     messages: list

--- a/back/src/graph/workflow.py
+++ b/back/src/graph/workflow.py
@@ -123,7 +123,13 @@ for qa_id in _SUPPORTED_QAS:
 builder.add_node("boot", boot_node)
 builder.add_node("context_loader", context_loader_node)
 builder.add_node("intake", intake_node)
-builder.add_edge("intake", "unifier")
+
+def _intake_next(state: GraphState) -> str:
+    # A2 sets nextNode="asr": route through supervisor so asr_node runs this turn.
+    # All other branches (B, C, D, A1, A3) use nextNode="unifier" → direct to unifier.
+    return "supervisor" if state.get("nextNode") == "asr" else "unifier"
+
+builder.add_conditional_edges("intake", _intake_next, {"supervisor": "supervisor", "unifier": "unifier"})
 builder.add_edge(START, "boot")
 builder.add_edge("boot", "context_loader")
 builder.add_edge("context_loader", "classifier")

--- a/back/src/graph/workflow.py
+++ b/back/src/graph/workflow.py
@@ -32,6 +32,7 @@ _TACTICS_QA_NODE_NAMES = {tactics_node_name_for_qa(qa) for qa in _SUPPORTED_QAS}
 
 def boot_node(state: GraphState) -> GraphState:
     """Resetea banderas y buffers al inicio de cada turno (sin borrar last_asr)."""
+    _idx = state.get("intake_current_field")
     return {
         **state,
         "hasVisitedInvestigator": False,
@@ -43,6 +44,10 @@ def boot_node(state: GraphState) -> GraphState:
         "requested_nodes": [],
         "pending_nodes": [],
         "completed_nodes": [],
+        # Intake defaults: initialize only when None (persists across turns otherwise)
+        "intake_fields":        state.get("intake_fields")   if state.get("intake_fields")   is not None else {},
+        "intake_current_field": _idx                         if _idx                         is not None else 0,
+        "intake_complete":      state.get("intake_complete") if state.get("intake_complete") is not None else False,
     }
 
 def router(state: GraphState) -> str:

--- a/back/src/graph/workflow.py
+++ b/back/src/graph/workflow.py
@@ -15,6 +15,7 @@ from src.graph.nodes.asr import asr_node
 from src.graph.nodes.styles import style_node, make_style_qa_node
 from src.graph.nodes.tactics import tactics_node, make_tactics_qa_node
 from src.graph.nodes.style_tactics_parallel import style_tactics_parallel_node
+from src.graph.nodes.intake_node import intake_node
 from src.graph.qa_registry import (
     normalize_qa,
     supported_qas,
@@ -47,6 +48,9 @@ def boot_node(state: GraphState) -> GraphState:
 def router(state: GraphState) -> str:
     if state["nextNode"] == "unifier":
         return "unifier"
+
+    if state["nextNode"] == "intake":
+        return "intake"
 
     if state["nextNode"] == "style_tactics_parallel":
         return "style_tactics_parallel"
@@ -113,6 +117,8 @@ for qa_id in _SUPPORTED_QAS:
 
 builder.add_node("boot", boot_node)
 builder.add_node("context_loader", context_loader_node)
+builder.add_node("intake", intake_node)
+builder.add_edge("intake", "unifier")
 builder.add_edge(START, "boot")
 builder.add_edge("boot", "context_loader")
 builder.add_edge("context_loader", "classifier")


### PR DESCRIPTION
This pull request introduces significant improvements to the architecture intake and validation flow, focusing on robust user input validation, better context injection for downstream nodes, and enhanced language detection. The changes ensure that intake answers are specific, technically detailed, and appropriately validated, improving both user experience and the quality of generated architectural recommendations.

**Intake validation and context injection:**

* Added a new `intake_validators.py` module with comprehensive deterministic and semantic validation for all intake fields, including checks for technical vocabulary, concrete metrics, and prevention of copy-pasted question text. Also includes LLM-based semantic validation and user reprompt messages.
* The ASR node now injects a structured "intake context" section into its prompt, summarizing architect-provided requirements and enforcing that the ASR is grounded in this real context, with support for both English and Spanish. [[1]](diffhunk://#diff-20e85ea0e1af0f00240d4cdd0280e39fa96d28a730bb219bb543765a3729698aR251-R295) [[2]](diffhunk://#diff-20e85ea0e1af0f00240d4cdd0280e39fa96d28a730bb219bb543765a3729698aL298-R343)

**Language detection and routing improvements:**

* Introduced a fast regex-based language detector in `classifier.py` to quickly and reliably determine the user's language during intake, avoiding unnecessary LLM calls and reducing the risk of spurious language switches on short/ambiguous messages. [[1]](diffhunk://#diff-46899c67c94b8a493158d743e7f3893ec44e92e5cbdbdc3a0f832fe70b4d48e0R1-R24) [[2]](diffhunk://#diff-46899c67c94b8a493158d743e7f3893ec44e92e5cbdbdc3a0f832fe70b4d48e0R69-R81)
* The supervisor node now logs phase/intent/nextNode and always routes to the intake node during the INTAKE phase, ensuring correct flow control.

**Unifier node handling:**

* The unifier node now handles the `intake` intent by simply returning the current end message, and fixes minor comments for clarity in other special-case handlers. [[1]](diffhunk://#diff-c0fe6fd7bb16195155e990c6d3e9a61172186f923b61491765378205e99fbd11L172-R175) [[2]](diffhunk://#diff-c0fe6fd7bb16195155e990c6d3e9a61172186f923b61491765378205e99fbd11L228-R231) [[3]](diffhunk://#diff-c0fe6fd7bb16195155e990c6d3e9a61172186f923b61491765378205e99fbd11L262-R265)