### PR TITLE
Merge feature-tutor-pro-mode into production with intake mode gate

### DIFF
--- a/back/docs_back/store.md
+++ b/back/docs_back/store.md
@@ -1,0 +1,54 @@
+# LangGraph Store API - Memoria Cross-Thread
+
+- Implementacion actual: `langgraph.store.memory.InMemoryStore`.
+- Ciclo de vida: instancia unica por proceso, creada en el `lifespan` de FastAPI
+  (ver `src/main.py`) y publicada via `set_store()` en `src/graph/resources.py`.
+- Persistencia: ephemeral. Los datos se pierden al reiniciar el proceso.
+  Cuando LangGraph publique un backend SQLite oficial (o se adopte
+  `langgraph-checkpoint-postgres` tambien para Store), reemplazar
+  `make_inmemory_store()` en `src/graph/resources.py` sin tocar los call-sites.
+
+## Namespaces estandarizados
+
+- `("user", user_id, "profile")` - perfil tecnico mantenido por el Shadow Agent (F3-T2).
+- `("user", user_id, "routines")` - retos generados por el Routine Generator (F5-T1).
+
+## Helpers
+
+```python
+from src.graph import get_store
+
+store = get_store()
+
+# Escritura
+await store.aput(
+    ("user", user_id, "profile"),
+    key="profile",
+    value={
+        "strengths": ["Modularidad"],
+        "weaknesses": ["Caching"],
+        "evaluated_concepts": [],
+        "updated_at": "2026-04-28T10:00:00Z",
+    },
+)
+
+# Lectura
+item = await store.aget(("user", user_id, "profile"), key="profile")
+profile = item.value if item else {}
+```
+
+`Store` es accesible desde cualquier nodo del grafo porque se inyecta en
+`builder.compile(store=...)`. Dentro de un nodo asincrono:
+
+```python
+async def my_node(state, *, store):
+    item = await store.aget(("user", state["user_id"], "profile"), key="profile")
+    profile = item.value if item else {}
+    ...
+```
+
+## Verificacion cross-thread
+
+Ver `back/tests/test_store_cross_thread.py`. El test escribe bajo el namespace
+del usuario y lee desde otro contexto sin reusar el `thread_id` del checkpointer,
+demostrando que el Store es independiente de la conversacion.

--- a/back/scripts/inspect_thread.py
+++ b/back/scripts/inspect_thread.py
@@ -1,0 +1,65 @@
+"""Inspecciona el estado persistido del checkpointer para un thread_id.
+
+Uso:
+    python back/scripts/inspect_thread.py phase2-smoke-persistence-thread-persist
+
+Demuestra que el AsyncSqliteSaver persiste GraphState entre reinicios y
+turnos. Imprime: numero de mensajes, snippet del primer y ultimo mensaje,
+campos clave del estado (mode, user_id, current_asr, quality_attribute).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+DB_PATH = Path(__file__).resolve().parents[1] / "state_db" / "graph_checkpoints.db"
+
+
+def _shorten(s: str, n: int = 200) -> str:
+    s = (s or "").replace("\n", " ").strip()
+    return s if len(s) <= n else s[:n] + "..."
+
+
+async def inspect(thread_id: str) -> None:
+    if not DB_PATH.exists():
+        raise SystemExit(f"DB no encontrada: {DB_PATH}")
+    print(f"DB: {DB_PATH}")
+    print(f"thread_id: {thread_id}")
+    print("-" * 70)
+
+    async with AsyncSqliteSaver.from_conn_string(str(DB_PATH)) as saver:
+        config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+        tup = await saver.aget_tuple(config)
+        if tup is None:
+            print("No hay estado persistido para ese thread_id.")
+            return
+
+        state = tup.checkpoint.get("channel_values", {})
+        msgs = state.get("messages") or []
+        print(f"Total mensajes en GraphState.messages: {len(msgs)}")
+        if msgs:
+            first = msgs[0]
+            last = msgs[-1]
+            print(f"  [primero] {type(first).__name__}: {_shorten(getattr(first, 'content', str(first)), 160)}")
+            print(f"  [ultimo]  {type(last).__name__}: {_shorten(getattr(last, 'content', str(last)), 160)}")
+
+        print("\nCampos clave del estado:")
+        for key in ("mode", "user_id", "language", "intent", "quality_attribute",
+                    "current_asr", "arch_stage", "user_profile", "mode_suggestion"):
+            val = state.get(key)
+            print(f"  {key:20s} = {_shorten(repr(val), 120)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("thread_id", help="thread_id (= session_id) a inspeccionar")
+    args = parser.parse_args()
+    asyncio.run(inspect(args.thread_id))
+
+
+if __name__ == "__main__":
+    main()

--- a/back/scripts/verify_checkpointer.py
+++ b/back/scripts/verify_checkpointer.py
@@ -1,0 +1,78 @@
+"""Verificacion del AsyncSqliteSaver para F1-T3.
+
+Apunta al mismo `state_db/graph_checkpoints.db` que usa el lifespan de FastAPI.
+Modos:
+    --write : abre el saver, persiste un checkpoint bajo un thread_id fijo.
+    --read  : abre el saver en un proceso distinto y verifica que recupera
+              el checkpoint persistido por el modo --write.
+
+Demostrar que `--read` recupera los datos despues de salir y volver a entrar
+prueba los criterios de F1-T3:
+- `state_db/graph_checkpoints.db` existe y es escrito por el checkpointer.
+- El grafo persiste el thread_id entre reinicios de proceso.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+DB_PATH = Path(__file__).resolve().parents[1] / "state_db" / "graph_checkpoints.db"
+THREAD_ID = "smoke-thread-1"
+
+
+def _build_minimal_checkpoint() -> dict:
+    """Estructura minima aceptada por el checkpointer de LangGraph."""
+    return {
+        "v": 1,
+        "id": "smoke-checkpoint-1",
+        "ts": "2026-04-29T00:00:00Z",
+        "channel_values": {"messages": []},
+        "channel_versions": {"messages": 1},
+        "versions_seen": {"__input__": {}},
+        "pending_sends": [],
+    }
+
+
+async def write_checkpoint() -> None:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    async with AsyncSqliteSaver.from_conn_string(str(DB_PATH)) as saver:
+        config = {"configurable": {"thread_id": THREAD_ID, "checkpoint_ns": ""}}
+        checkpoint = _build_minimal_checkpoint()
+        await saver.aput(config, checkpoint, {"source": "smoke"}, {})
+    size = DB_PATH.stat().st_size
+    print(f"[write] OK | path={DB_PATH} | size={size} bytes | thread_id={THREAD_ID}")
+
+
+async def read_checkpoint() -> None:
+    if not DB_PATH.exists():
+        raise SystemExit(f"[read] FAIL: db not found at {DB_PATH}")
+    async with AsyncSqliteSaver.from_conn_string(str(DB_PATH)) as saver:
+        config = {"configurable": {"thread_id": THREAD_ID, "checkpoint_ns": ""}}
+        tup = await saver.aget_tuple(config)
+        if tup is None:
+            raise SystemExit(f"[read] FAIL: no checkpoint for thread_id={THREAD_ID}")
+        print(
+            f"[read] OK | thread_id={THREAD_ID} | "
+            f"checkpoint_id={tup.checkpoint['id']} | "
+            f"ts={tup.checkpoint['ts']}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--write", action="store_true", help="persistir checkpoint")
+    group.add_argument("--read", action="store_true", help="leer checkpoint persistido")
+    args = parser.parse_args()
+    if args.write:
+        asyncio.run(write_checkpoint())
+    else:
+        asyncio.run(read_checkpoint())
+
+
+if __name__ == "__main__":
+    main()

--- a/back/src/graph/__init__.py
+++ b/back/src/graph/__init__.py
@@ -1,4 +1,17 @@
+from src.graph.workflow import build_graph
+from src.graph.resources import (
+    get_graph,
+    set_graph,
+    get_store,
+    set_store,
+    make_inmemory_store,
+)
 
-from src.graph.workflow import graph
-
-__all__ = ["graph"]
+__all__ = [
+    "build_graph",
+    "get_graph",
+    "set_graph",
+    "get_store",
+    "set_store",
+    "make_inmemory_store",
+]

--- a/back/src/graph/nodes/asr.py
+++ b/back/src/graph/nodes/asr.py
@@ -6,6 +6,7 @@ from langchain_core.messages import AIMessage
 from src.graph.resources import llm, rag_trace_record
 from src.graph.state import GraphState
 from src.graph.consts import MARKDOWN_FORMAT_DIRECTIVE
+from src.graph.prompts.mode_prompts import apply_mode_prompt
 from src.graph.utils import (
     _clip_text,
     _dedupe_snippets,
@@ -385,7 +386,7 @@ Rules:
 {"RECORDATORIO FINAL: responde completamente en español." if lang == "es" else "FINAL REMINDER: answer entirely in English."}
 """
 
-    result = llm.invoke(prompt)
+    result = llm.invoke(apply_mode_prompt(state, prompt))
     content_raw = getattr(result, "content", str(result))
     content = _sanitize_response(content_raw)
     content = _strip_tactics_sections(content)

--- a/back/src/graph/nodes/classifier.py
+++ b/back/src/graph/nodes/classifier.py
@@ -1,3 +1,4 @@
+import os
 import re
 from functools import lru_cache
 from src.services.llm_factory import get_chat_model
@@ -23,6 +24,49 @@ def _detect_lang_fast(msg: str) -> str:
     return "es" if _ES_MARKERS.search(msg) else "en"
 
 llm = get_chat_model(temperature=0.0)
+
+
+# ===== F2-T4: Heuristica de auto-routing de modo =====
+# Triggers bilingues (ES/EN). Cada match suma 0.5 al score (cap 1.0).
+TUTOR_TRIGGERS = (
+    r"\bexpl[ií]came\b", r"\bense[ñn]ame\b", r"\bno\s+entiendo\b",
+    r"\bqu[eé]\s+es\b", r"\bqu[eé]\s+significa\b",
+    r"\bay[uú]dame\s+a\s+entender\b", r"\bduda\b", r"\bconcept[oa]\b",
+    r"\bexplain\b", r"\bteach\s+me\b", r"\bwhat\s+is\b",
+    r"\bdon'?t\s+understand\b", r"\bdoubt\b",
+)
+PROFESSIONAL_TRIGGERS = (
+    r"\bimplementa(?:me|lo)?\b", r"\bdame\s+(?:el\s+)?c[oó]digo\b",
+    r"\bmu[eé]strame\b", r"\bdiagrama\b", r"\bdise[ñn]a\b",
+    r"\boptimiza\b", r"\bbenchmark\b", r"\barquitectura\s+de\b",
+    r"\bimplement\b", r"\bgive\s+me\s+the\s+code\b", r"\bdesign\s+the\b",
+    r"\bbuild\b", r"\boptimize\b", r"\bcompare\s+latency\b",
+)
+
+_MODE_SUGGESTION_THRESHOLD = float(os.getenv("MODE_SUGGESTION_THRESHOLD", "0.7"))
+
+
+def _score_triggers(text: str, patterns: tuple) -> float:
+    """Confianza en [0,1]: 1 match = 0.8, 2+ saturan a 1.0.
+
+    Calibrado para que un unico verbo de intencion claro (ej. 'explicame',
+    'dame el codigo') ya supere el umbral default 0.7, y multiples matches
+    converjan rapido a 1.0.
+    """
+    matches = sum(1 for p in patterns if re.search(p, text or "", re.IGNORECASE))
+    return 0.0 if matches == 0 else min(1.0, 0.8 + 0.2 * (matches - 1))
+
+
+def suggest_mode(text: str, current_mode: str):
+    """Devuelve `tutor` / `professional` si la confianza supera el umbral
+    Y el modo sugerido difiere del actual. None si no aplica."""
+    tutor_conf = _score_triggers(text, TUTOR_TRIGGERS)
+    pro_conf = _score_triggers(text, PROFESSIONAL_TRIGGERS)
+    if tutor_conf >= _MODE_SUGGESTION_THRESHOLD and tutor_conf > pro_conf:
+        return "tutor" if current_mode != "tutor" else None
+    if pro_conf >= _MODE_SUGGESTION_THRESHOLD and pro_conf > tutor_conf:
+        return "professional" if current_mode != "professional" else None
+    return None
 
 FOLLOWUP_PATTERNS = [
     ("explain_tactics", r"\b(tactics?|tácticas?).*(explain|describe|detalla|explica)|explica.*tácticas"),
@@ -69,13 +113,11 @@ def classifier_node(state: GraphState) -> GraphState:
     # During INTAKE the supervisor routes to intake_node regardless of intent.
     # Skip the LLM call to preserve intent="intake" and avoid spurious QA overrides,
     # but still detect language so intake_node responds in the user's language.
-    if (state.get("current_phase") or "") == "INTAKE":
+    # Gate: intake phase only applies in professional mode.
+    if (state.get("current_phase") or "") == "INTAKE" and (state.get("mode") or "professional") != "tutor":
         msg = state.get("userQuestion", "") or ""
         prior_lang = state.get("language") or "es"
         detected = _detect_lang_fast(msg)
-        # Only switch to "en" when there is positive English evidence (message long
-        # enough to carry signal). Short/ambiguous messages like "no", "ok", "genera"
-        # must not flip the language the user established earlier in the session.
         lang = detected if (detected == "es" or len(msg.split()) > 2) else prior_lang
         return {**state, "language": lang}
 
@@ -161,6 +203,11 @@ def classifier_node(state: GraphState) -> GraphState:
     else:
         quality_attribute = "general"
 
+    # F2-T4: heuristica de auto-routing de modo. Si el usuario muestra
+    # intencion de pedagogia/operatividad y el modo actual no coincide,
+    # exponemos `mode_suggestion` para que el Frontend ofrezca el cambio.
+    mode_suggestion = suggest_mode(msg, state.get("mode") or "professional")
+
     return {
         **state,
         "language": lang,
@@ -177,4 +224,5 @@ def classifier_node(state: GraphState) -> GraphState:
         "force_rag": bool(use_rag),
         "resolved_index": resolved_index,
         "quality_attribute": quality_attribute,
+        "mode_suggestion": mode_suggestion,
     }

--- a/back/src/graph/nodes/investigator.py
+++ b/back/src/graph/nodes/investigator.py
@@ -6,8 +6,11 @@ from langgraph.prebuilt import create_react_agent
 from src.graph.state import GraphState
 from src.graph.resources import llm, _HAS_VERTEX
 from src.graph.consts import prompt_researcher
+from src.graph.prompts.mode_prompts import apply_mode_prompt
 from src.graph.utils import _push_turn, _last_k_messages, _clip_text
 from src.graph.nodes.tools import local_RAG, LLM, LLMWithImages
+from src.graph.nodes.tools_tutor import lookup_glossary, cite_documentation
+from src.graph.nodes.tools_professional import python_repl_tool, local_rag_advanced
 
 _SOURCES_BLOCK_RE = re.compile(r"SOURCES:\s*[\s\S]*", re.I)
 
@@ -95,6 +98,7 @@ def researcher_node(state: GraphState) -> GraphState:
             f"específicos del atributo de calidad '{resolved_index}'."
         )
 
+    sys = apply_mode_prompt(state, sys)
     system_message = SystemMessage(content=sys)
     _push_turn(state, role="system", name="researcher_system", content=sys)
 
@@ -107,8 +111,18 @@ def researcher_node(state: GraphState) -> GraphState:
         SystemMessage(content=f"PROJECT CONTEXT:\n{ctx_for_prompt}") if ctx_for_prompt else None
     )
 
-    # Herramientas: sin RAG en DOC-ONLY
-    tools = ([LLM] + ([LLMWithImages] if _HAS_VERTEX else [])) if doc_only else ([local_RAG, LLM] + ([LLMWithImages] if _HAS_VERTEX else []))
+    # Herramientas base (sin RAG en DOC-ONLY).
+    base_tools = [LLM] + ([LLMWithImages] if _HAS_VERTEX else [])
+    if not doc_only:
+        base_tools = [local_RAG] + base_tools
+    # F2-T5 / F2-T6: gating por modo. Tutor obtiene glossary tools;
+    # Profesional obtiene REPL + RAG avanzado.
+    mode = state.get("mode") or "professional"
+    if mode == "tutor":
+        base_tools = base_tools + [lookup_glossary, cite_documentation]
+    elif mode == "professional":
+        base_tools = base_tools + [python_repl_tool, local_rag_advanced]
+    tools = base_tools
     agent = create_react_agent(llm, tools=tools)
 
     # HINT corto (solo si no estamos en DOC-ONLY)

--- a/back/src/graph/nodes/profile_shadow.py
+++ b/back/src/graph/nodes/profile_shadow.py
@@ -1,0 +1,255 @@
+"""Shadow Agent / Profile Evaluator (F3-T2).
+
+Ejecuta una evaluacion del perfil del usuario fuera del path critico del
+turno. Llamado por `fire_shadow_eval` desde el unifier al final del turno
+si la cadencia se cumple. Escribe el resultado en el LangGraph Store bajo
+el namespace `("user", user_id, "profile")`.
+
+Cadencia y ventana son configurables via env:
+- SHADOW_AGENT_EVERY_N_TURNS (default 4)
+- SHADOW_AGENT_WINDOW_SIZE  (default 6)
+
+La persistencia al Backend Negocio (PostgreSQL) llega con F3-T5 (cliente
+HTTP). Esta capa solo escribe al Store in-process.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from src.graph.resources import get_store, llm
+from src.graph.schemas.profile import ConceptScore, UserProfileEvaluation
+from src.services.profile_sync import sync_profile
+
+log = logging.getLogger("shadow_agent")
+
+SHADOW_EVERY_N = int(os.getenv("SHADOW_AGENT_EVERY_N_TURNS", "4"))
+SHADOW_WINDOW = int(os.getenv("SHADOW_AGENT_WINDOW_SIZE", "6"))
+
+# Tracking de tasks fire-and-forget para prevenir GC prematuro.
+_pending_tasks: set = set()
+
+
+def should_trigger(turn_count_since_eval: int) -> bool:
+    """True si la cadencia se cumple y conviene disparar la evaluacion."""
+    return (turn_count_since_eval or 0) >= SHADOW_EVERY_N
+
+
+# ---- Evaluacion via LLM -------------------------------------------------
+
+_EVAL_PROMPT = """\
+You are a profiling agent. Analyze the recent exchange between USER and
+ASSISTANT, then identify:
+- strengths: architectural concepts the USER demonstrates mastery on.
+- weaknesses: concepts the USER avoids, asks about, or gets wrong.
+- evaluated_concepts: per-concept score in [0,1] with short evidence.
+- confidence: overall confidence in [0,1] given the available signal.
+- delta_from_previous: dict mapping concept name to mastery delta vs prior.
+  Leave empty if you cannot infer it.
+
+Be conservative: only include concepts with explicit signal in messages.
+If signal is weak, return empty lists with confidence < 0.5.
+
+RECENT EXCHANGE:
+{window}
+"""
+
+
+def _format_messages_window(messages: list, window: int) -> str:
+    """Devuelve texto pretty-printed con las ultimas `window` mensajes."""
+    tail = list(messages or [])[-window:]
+    out = []
+    for m in tail:
+        role = "USER" if isinstance(m, HumanMessage) else "ASSISTANT"
+        content = getattr(m, "content", str(m))
+        if not isinstance(content, str):
+            content = str(content)
+        content = content.replace("\n", " ").strip()[:600]
+        out.append(f"[{role}] {content}")
+    return "\n\n".join(out) if out else "(empty conversation)"
+
+
+async def evaluate_messages(messages: list, llm_obj=None) -> UserProfileEvaluation:
+    """Llama al LLM con structured_output(UserProfileEvaluation) sobre la ventana.
+
+    Usa `method="function_calling"` para evitar el modo `json_schema` de
+    OpenAI (langchain-openai >= 0.3) que exige `required` con todas las
+    propiedades. Nuestro schema tiene defaults via `default_factory`
+    (strengths/weaknesses/evaluated_concepts/delta_from_previous), por lo
+    que el modo function_calling es la opcion compatible.
+    """
+    llm_obj = llm_obj if llm_obj is not None else llm
+    structured = llm_obj.with_structured_output(
+        UserProfileEvaluation, method="function_calling"
+    )
+    prompt = _EVAL_PROMPT.format(window=_format_messages_window(messages, SHADOW_WINDOW))
+    return await structured.ainvoke(prompt)
+
+
+# ---- Merge ponderado ----------------------------------------------------
+
+def _union_names(prev_list, new_names):
+    """Union case-insensitive preservando primer nombre canonico visto."""
+    seen = {}
+    for s in (prev_list or []):
+        if isinstance(s, str) and s.strip():
+            seen.setdefault(s.casefold(), s)
+    for s in (new_names or []):
+        if isinstance(s, str) and s.strip():
+            seen.setdefault(s.casefold(), s)
+    return list(seen.values())
+
+
+def merge_profile(prev: dict, new: UserProfileEvaluation, alpha: float = 0.7) -> dict:
+    """Mergea perfil previo con nueva evaluacion via promedio ponderado.
+
+    - mastery_merged = alpha * new + (1 - alpha) * prev
+    - strengths / weaknesses: union case-insensitive (prev gana en empate).
+    - delta_from_previous: diff de mastery (positivo = mejora).
+    - F3-T4: cada concepto evaluado en `new` recibe `last_seen_at = now_iso`
+      (refuerzo). Conceptos solo-en-prev preservan su `last_seen_at` previo.
+    """
+    prev = prev or {}
+    prev_concepts_idx = {
+        (c.get("name") or "").casefold(): c
+        for c in (prev.get("evaluated_concepts") or [])
+        if isinstance(c, dict) and c.get("name")
+    }
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    merged_concepts: List[dict] = []
+    deltas: dict = {}
+    seen_keys = set()
+
+    for c in (new.evaluated_concepts or []):
+        key = c.name.casefold()
+        seen_keys.add(key)
+        prev_c = prev_concepts_idx.get(key)
+        if prev_c is not None:
+            try:
+                prev_m = float(prev_c.get("mastery") or 0.0)
+            except (TypeError, ValueError):
+                prev_m = 0.0
+            new_m = alpha * float(c.mastery) + (1 - alpha) * prev_m
+            deltas[c.name] = round(new_m - prev_m, 4)
+        else:
+            new_m = float(c.mastery)
+            deltas[c.name] = round(new_m, 4)
+        merged_concepts.append(
+            {
+                "name": c.name,
+                "mastery": round(new_m, 4),
+                "evidence": c.evidence or "",
+                "last_seen_at": now_iso,
+            }
+        )
+
+    # Conceptos en prev pero no en new se preservan (last_seen_at queda igual).
+    for key, prev_c in prev_concepts_idx.items():
+        if key not in seen_keys:
+            merged_concepts.append(prev_c)
+
+    strengths = _union_names(prev.get("strengths"), [c.name for c in (new.strengths or [])])
+    weaknesses = _union_names(prev.get("weaknesses"), [c.name for c in (new.weaknesses or [])])
+
+    return {
+        "user_id": prev.get("user_id", ""),
+        "strengths": strengths,
+        "weaknesses": weaknesses,
+        "evaluated_concepts": merged_concepts,
+        "confidence": float(new.confidence),
+        "delta_from_previous": deltas,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+# ---- Task entry point ---------------------------------------------------
+
+async def shadow_eval_async(user_id: str, messages: list, llm_obj=None, store=None) -> Optional[dict]:
+    """Punto de entrada del task fire-and-forget.
+
+    - Si user_id vacio o messages < 2 -> no hace nada.
+    - Si la evaluacion falla, NO escribe al Store (perfil previo intacto).
+    - Logs explicitos: shadow_eval started/completed/failed.
+
+    Devuelve el dict mergeado escrito al Store, o None si no se persistio.
+    """
+    user_id = (user_id or "").strip()
+    if not user_id:
+        log.debug("shadow_eval skipped: empty user_id")
+        return None
+    if len(messages or []) < 2:
+        log.debug("shadow_eval skipped: messages window too small (%d)", len(messages or []))
+        return None
+
+    log.info("shadow_eval started for user_id=%s (msgs=%d)", user_id, len(messages))
+    try:
+        evaluation = await evaluate_messages(messages, llm_obj=llm_obj)
+    except Exception as exc:
+        log.exception("shadow_eval failed for user_id=%s: %s", user_id, exc)
+        return None
+
+    try:
+        store_obj = store if store is not None else get_store()
+        ns = ("user", user_id, "profile")
+        existing = await store_obj.aget(ns, key="profile")
+        prev = (existing.value if existing else {}) or {}
+        if not isinstance(prev, dict):
+            prev = {}
+        prev.setdefault("user_id", user_id)
+        merged = merge_profile(prev, evaluation)
+        merged["user_id"] = user_id
+        await store_obj.aput(ns, key="profile", value=merged)
+    except Exception as exc:
+        log.exception("shadow_eval persistence failed for user_id=%s: %s", user_id, exc)
+        return None
+
+    log.info(
+        "shadow_eval completed for user_id=%s (concepts=%d, conf=%.2f)",
+        user_id,
+        len(merged.get("evaluated_concepts", [])),
+        float(merged.get("confidence", 0.0)),
+    )
+
+    # F3-T5: sync HTTP a Backend Negocio. Best-effort: si falla, el perfil
+    # ya esta seguro en el Store local. NUNCA lanza al caller.
+    try:
+        await sync_profile(user_id, merged)
+    except Exception:
+        log.exception("profile_sync raised unexpectedly for user_id=%s", user_id)
+
+    return merged
+
+
+def fire_shadow_eval(state: dict, final_text: str = "") -> Optional["asyncio.Task"]:
+    """Lanza fire-and-forget el shadow eval si la cadencia se cumple.
+
+    - Llama al loop async actual via `asyncio.get_running_loop()`.
+    - Mantiene la task en `_pending_tasks` para evitar GC prematuro.
+    - Devuelve la Task lanzada, o None si no se pudo disparar.
+    """
+    if not should_trigger(state.get("turn_count_since_eval", 0) or 0):
+        return None
+    user_id = (state.get("user_id") or "").strip()
+    if not user_id:
+        return None
+
+    messages = list(state.get("messages") or [])
+    if final_text:
+        messages = messages + [AIMessage(content=final_text, name="unifier")]
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        log.warning("shadow_eval skipped: no running event loop")
+        return None
+
+    task = loop.create_task(shadow_eval_async(user_id, messages))
+    _pending_tasks.add(task)
+    task.add_done_callback(_pending_tasks.discard)
+    return task

--- a/back/src/graph/nodes/styles/common.py
+++ b/back/src/graph/nodes/styles/common.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from src.graph.resources import llm, rag_trace_record
 from src.graph.state import GraphState
 from src.graph.qa_registry import normalize_qa
+from src.graph.prompts.mode_prompts import apply_mode_prompt
 from src.rag_agent import get_indexed_retriever
 from src.graph.utils import _dedupe_snippets
 from src.ledger import (
@@ -294,7 +295,7 @@ Do NOT add comments or any text outside of this JSON object.
 All string values in the JSON (name, impact, rationale) MUST be written in {"English" if lang == "en" else "español"}.
 """
 
-    result = llm.invoke(prompt)
+    result = llm.invoke(apply_mode_prompt(state, prompt))
     raw = getattr(result, "content", str(result))
 
     try:

--- a/back/src/graph/nodes/supervisor.py
+++ b/back/src/graph/nodes/supervisor.py
@@ -172,7 +172,7 @@ def supervisor_node(state: GraphState):
         state.get("current_phase"), state.get("intent"), state.get("nextNode"),
     )
 
-    if (state.get("current_phase") or "") == "INTAKE":
+    if (state.get("current_phase") or "") == "INTAKE" and (state.get("mode") or "professional") != "tutor":
         return {**state, "nextNode": "intake", "localQuestion": ""}
 
     # si ya hay un SVG listo en este turno, vamos directo al unifier

--- a/back/src/graph/nodes/tactics/common.py
+++ b/back/src/graph/nodes/tactics/common.py
@@ -22,6 +22,7 @@ from src.graph.utils import (
     _json_only_repair_pass,
 )
 from src.graph.consts import TACTICS_JSON_EXAMPLE, MARKDOWN_FORMAT_DIRECTIVE
+from src.graph.prompts.mode_prompts import apply_mode_prompt
 from src.graph.qa_registry import normalize_qa
 from src.ledger import (
     append_decision,
@@ -430,7 +431,7 @@ Example shape (values are illustrative — adjust to your tactics):
 
 {"RECORDATORIO FINAL: toda tu respuesta (secciones de texto y valores JSON) debe estar en español." if lang == "es" else "FINAL REMINDER: your entire response (text sections and JSON string values) must be in English."}
 """
-    resp = llm.invoke(prompt)
+    resp = llm.invoke(apply_mode_prompt(state, prompt))
     raw = getattr(resp, "content", str(resp)).strip()
 
     log.debug("tactics raw (first 400): %s", raw[:400].replace("\n", " "))

--- a/back/src/graph/nodes/tools_professional.py
+++ b/back/src/graph/nodes/tools_professional.py
@@ -1,0 +1,136 @@
+"""Tools especificas del Modo Profesional (F2-T6).
+
+- python_repl_tool: ejecuta codigo Python en subproceso con timeout 5s y
+  AST guard que bloquea imports peligrosos. NO es un sandbox completo;
+  ver limitaciones documentadas en el docstring.
+- local_rag_advanced: retorna top-K con scores explicitos, ordenados por
+  similitud semantica (descendente).
+
+Solo se registran cuando state["mode"] == "professional" en el investigador.
+"""
+from __future__ import annotations
+import ast
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from langchain_core.tools import tool
+from src.rag_agent import get_indexed_retriever
+
+
+# ---- python_repl_tool ----------------------------------------------------
+
+_BANNED_TOP_LEVEL_NAMES = {"os", "subprocess", "socket"}
+_BANNED_BUILTINS = {"__import__", "exec", "eval", "open"}
+
+
+def _ast_guard(code: str):
+    """Devuelve None si el codigo es aceptable; mensaje de error si no."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as e:
+        return f"SyntaxError: {e}"
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                root = (n.name or "").split(".")[0]
+                if root in _BANNED_TOP_LEVEL_NAMES:
+                    return f"Import of {root!r} is not allowed."
+        if isinstance(node, ast.ImportFrom):
+            root = (node.module or "").split(".")[0]
+            if root in _BANNED_TOP_LEVEL_NAMES:
+                return f"Import from {root!r} is not allowed."
+        if isinstance(node, ast.Name) and node.id in _BANNED_BUILTINS:
+            return f"Use of builtin {node.id!r} is not allowed."
+    return None
+
+
+@tool
+def python_repl_tool(code: str) -> str:
+    """Ejecuta codigo Python en un subproceso aislado.
+
+    Restricciones:
+    - Timeout 5 segundos (proceso terminado al exceder).
+    - AST guard rechaza `import os`, `import subprocess`, `import socket`,
+      y los builtins __import__, exec, eval, open.
+    - CWD aislado en directorio temporal, eliminado al terminar.
+
+    LIMITACIONES (no es un sandbox completo):
+    - NO bloquea acceso a red a nivel SO; un import alternativo podria
+      hacer requests si no esta en la lista negra. Para produccion real,
+      usar Docker / RestrictedPython.
+    - Habilitado solo si env ENABLE_PYTHON_REPL == "true".
+    """
+    if os.getenv("ENABLE_PYTHON_REPL", "false").lower() != "true":
+        return "python_repl_tool is disabled (set ENABLE_PYTHON_REPL=true to enable)."
+
+    err = _ast_guard(code)
+    if err:
+        return f"REPL_BLOCKED: {err}"
+
+    sandbox = tempfile.mkdtemp(prefix="archia-repl-")
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=sandbox,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        out = (proc.stdout or "").strip()
+        err_out = (proc.stderr or "").strip()
+        if proc.returncode != 0:
+            return f"EXIT={proc.returncode}\nSTDOUT:\n{out}\nSTDERR:\n{err_out}"
+        return out or "(no stdout)"
+    except subprocess.TimeoutExpired:
+        return "REPL_TIMEOUT: execution exceeded 5 seconds and was terminated."
+    finally:
+        shutil.rmtree(sandbox, ignore_errors=True)
+
+
+# ---- local_rag_advanced --------------------------------------------------
+
+@tool
+def local_rag_advanced(query: str, quality_attribute: str = "general", k: int = 6) -> str:
+    """RAG avanzado: top-K con scores explicitos, ordenado por similitud.
+
+    A diferencia de `local_RAG`, este expone los scores y el orden semantico
+    para razonamiento downstream. Devuelve JSON con:
+    {results: [{rank, score, snippet, source}, ...], total: N}.
+    """
+    try:
+        retr = get_indexed_retriever(quality_attribute=quality_attribute, k=k)
+        # Acceso directo al vectorstore para usar similarity_search_with_score.
+        vs = getattr(retr, "vectorstore", None)
+        if vs is None or not hasattr(vs, "similarity_search_with_score"):
+            # Fallback: invoke sin score, score=0.0
+            docs = list(retr.invoke(query))
+            scored = [(d, 0.0) for d in docs]
+        else:
+            scored = vs.similarity_search_with_score(query, k=k)
+        # Chroma scores: distancia, menor = mas similar. Convertimos a similitud.
+        scored.sort(key=lambda t: t[1])
+        results = []
+        for i, (d, dist) in enumerate(scored[:k], start=1):
+            md = d.metadata or {}
+            title = md.get("source_title") or md.get("title") or "doc"
+            page = md.get("page_label") or md.get("page")
+            path = md.get("source_path") or md.get("source") or ""
+            page_str = f" (p.{page})" if page is not None else ""
+            results.append({
+                "rank": i,
+                "score": float(1.0 / (1.0 + float(dist))),
+                "snippet": (d.page_content or "").strip()[:300],
+                "source": f"{title}{page_str} - {path}".strip(),
+            })
+        return json.dumps(
+            {"query": query, "total": len(results), "results": results},
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        return json.dumps(
+            {"query": query, "error": str(e), "results": [], "total": 0}
+        )

--- a/back/src/graph/nodes/tools_tutor.py
+++ b/back/src/graph/nodes/tools_tutor.py
@@ -1,0 +1,77 @@
+"""Tools especificas del Modo Tutor (F2-T5).
+
+Solo se registran cuando state["mode"] == "tutor" en el investigador.
+Filtran el RAG existente por metadata.kind == "glossary" para responder
+con definiciones cortas y citas a documentacion oficial.
+"""
+from __future__ import annotations
+from langchain_core.tools import tool
+from src.rag_agent import get_indexed_retriever
+
+
+def _glossary_search(query: str, k: int = 4) -> list:
+    """Helper: retriever filtrado por kind='glossary'."""
+    retr = get_indexed_retriever(quality_attribute="general", k=k)
+    try:
+        # Filtro Mongo-like compatible con Chroma del proyecto.
+        retr.search_kwargs = {
+            **(retr.search_kwargs or {}),
+            "filter": {"kind": {"$eq": "glossary"}},
+        }
+        return list(retr.invoke(query))
+    except Exception:
+        return []
+
+
+@tool
+def lookup_glossary(term: str) -> dict:
+    """Busca una definicion corta del termino en el corpus de glosario.
+
+    Devuelve {term, definition, source}. Si no hay entradas glossary en el
+    corpus, retorna definition vacia y nota explicativa en source.
+    """
+    docs = _glossary_search(term, k=2)
+    if not docs:
+        return {
+            "term": term,
+            "definition": "",
+            "source": "(no glossary entries available; fallback to local_RAG)",
+        }
+    d = docs[0]
+    md = d.metadata or {}
+    title = md.get("source_title") or md.get("title") or "doc"
+    page = md.get("page_label") or md.get("page")
+    page_str = f" (p.{page})" if page is not None else ""
+    return {
+        "term": term,
+        "definition": (d.page_content or "").strip()[:500],
+        "source": f"{title}{page_str}",
+    }
+
+
+@tool
+def cite_documentation(concept: str) -> dict:
+    """Devuelve referencia a documentacion oficial sobre el concepto.
+
+    Devuelve {concept, citation, snippet}. Usa el mismo filtro glossary.
+    """
+    docs = _glossary_search(concept, k=3)
+    if not docs:
+        return {
+            "concept": concept,
+            "citation": "(no glossary entries available)",
+            "snippet": "",
+        }
+    items = []
+    for d in docs:
+        md = d.metadata or {}
+        title = md.get("source_title") or md.get("title") or "doc"
+        page = md.get("page_label") or md.get("page")
+        path = md.get("source_path") or md.get("source") or ""
+        page_str = f" (p.{page})" if page is not None else ""
+        items.append(f"- {title}{page_str} - {path}")
+    return {
+        "concept": concept,
+        "citation": "\n".join(items),
+        "snippet": (docs[0].page_content or "").strip()[:400],
+    }

--- a/back/src/graph/nodes/unifier.py
+++ b/back/src/graph/nodes/unifier.py
@@ -6,7 +6,19 @@ from langchain_core.messages import AIMessage
 from src.graph.state import GraphState
 from src.graph.resources import llm
 from src.graph.consts import MARKDOWN_FORMAT_DIRECTIVE
+from src.graph.prompts.mode_prompts import apply_mode_prompt
+from src.graph.nodes.profile_shadow import fire_shadow_eval, should_trigger
 from src.graph.utils import _push_turn, _strip_tactics_sections
+
+
+def _finalize_turn(state: GraphState, final_text: str) -> GraphState:
+    """F3-T2: dispara shadow eval (fire-and-forget) si la cadencia se cumple
+    y resetea `turn_count_since_eval`. Devuelve el state actualizado para
+    que el caller lo incluya en el dict de retorno."""
+    if should_trigger(state.get("turn_count_since_eval", 0) or 0):
+        fire_shadow_eval(state, final_text=final_text)
+        return {**state, "turn_count_since_eval": 0}
+    return state
 
 def _last_ai_by(state: GraphState, name: str) -> str:
     for m in reversed(state["messages"]):
@@ -68,7 +80,7 @@ def _ensure_section(title: str, body: str) -> str:
         return body
     return f"{title}\n\n{body}"
 
-def unifier_node(state: GraphState) -> GraphState:
+async def unifier_node(state: GraphState) -> GraphState:
     lang = state.get("language", "es")
     intent = state.get("intent", "general")
     style_hint = (state.get("user_style_hint") or "").strip()
@@ -136,6 +148,7 @@ def unifier_node(state: GraphState) -> GraphState:
             state["turn_messages"] = state.get("turn_messages", []) + [
                 {"role": "assistant", "name": "unifier", "content": end_text}
             ]
+            state = _finalize_turn(state, end_text)
             return {**state, "endMessage": end_text, "intent": ("diagram" if "diagram_agent" in requested_set else intent)}
 
     # 0) Show rendered diagram if available
@@ -167,9 +180,11 @@ def unifier_node(state: GraphState) -> GraphState:
 {footer}
 """
         state["suggestions"] = tips
+        state = _finalize_turn(state, end_text)
         return {**state, "endMessage": end_text, "intent": "diagram"}
 
     if intent == "intake":
+        state = _finalize_turn(state, state.get("endMessage") or "")
         return {**state, "endMessage": state.get("endMessage") or ""}
 
     # 🔴 Caso especial para ESTILOS
@@ -195,6 +210,7 @@ def unifier_node(state: GraphState) -> GraphState:
         state["turn_messages"] = state.get("turn_messages", []) + [
             {"role": "assistant", "name": "unifier", "content": style_txt}
         ]
+        state = _finalize_turn(state, style_txt)
         return {**state, "endMessage": style_txt}
 
     # ðŸ"´ Caso especial para TÁCTICAS
@@ -226,6 +242,7 @@ def unifier_node(state: GraphState) -> GraphState:
         state["turn_messages"] = state.get("turn_messages", []) + [
             {"role": "assistant", "name": "unifier", "content": end_text}
         ]
+        state = _finalize_turn(state, end_text)
         return {**state, "endMessage": end_text}
 
     # ðŸ"´ Caso especial para ASR
@@ -260,6 +277,7 @@ def unifier_node(state: GraphState) -> GraphState:
             {"role": "assistant", "name": "unifier", "content": end_text}
         ]
         state["suggestions"] = followups
+        state = _finalize_turn(state, end_text)
         return {**state, "endMessage": end_text}
 
     # ðŸ"´ Caso especial: saludo / smalltalk
@@ -287,6 +305,7 @@ def unifier_node(state: GraphState) -> GraphState:
 
         end_text = hello + "\n\n" + footer
         state["suggestions"] = nexts
+        state = _finalize_turn(state, end_text)
         return {**state, "endMessage": end_text}
 
     # ðŸ"µ Caso por defecto: síntesis de investigador / evaluador / etc.
@@ -360,7 +379,7 @@ SOURCE:
 {"RECORDATORIO FINAL: toda tu respuesta debe estar en español." if lang == "es" else "FINAL REMINDER: your entire response must be in English."}
 """
 
-    resp = llm.invoke(prompt)
+    resp = await llm.ainvoke(apply_mode_prompt(state, prompt))
     final_text = getattr(resp, "content", str(resp))
     final_text = _strip_mermaid_artifacts(final_text)
 
@@ -376,5 +395,6 @@ SOURCE:
     _push_turn(state, role="system", name="unifier_system", content=prompt)
     _push_turn(state, role="assistant", name="unifier", content=final_text)
 
+    state = _finalize_turn(state, final_text)
     return {**state, "endMessage": final_text}
 

--- a/back/src/graph/prompts/mode_prompts.py
+++ b/back/src/graph/prompts/mode_prompts.py
@@ -1,0 +1,52 @@
+"""System prompts diferenciados por modo de interaccion.
+
+- TUTOR: metodo socratico, exige reflexion, evita dar la respuesta directa.
+- PROFESSIONAL: consultor senior L4+, soluciones directas, codigo y diagramas.
+
+Se inyectan como prefijo del prompt de cada nodo afectado (F2-T3),
+una sola vez por turno (no acumulados).
+"""
+from __future__ import annotations
+from typing import Mapping, Any
+
+
+TUTOR_SYSTEM_PROMPT = """\
+Actua como un tutor experto en arquitectura de software con metodo socratico.
+Tu prioridad es PEDAGOGIA: ayuda al usuario a llegar a la respuesta por si mismo.
+Reglas obligatorias:
+- Hace al menos UNA pregunta socratica al inicio de la respuesta.
+- Si el usuario pide directamente la solucion, responde con preguntas guiadas y analogias antes de revelar la respuesta completa.
+- Usa analogias concretas (objetos cotidianos, eventos historicos, otros sistemas).
+- Define en lenguaje simple cualquier termino tecnico antes de usarlo.
+- Cierra con una pregunta de verificacion ("Que pasaria si...?", "Por que crees que...?").
+Estilo: cercano, paciente, claro. Evita jerga sin explicarla.
+"""
+
+
+PROFESSIONAL_SYSTEM_PROMPT = """\
+Actua como un Architect Lead L4+ con experiencia en sistemas a escala.
+Tu prioridad es ENTREGAR VALOR TECNICO inmediato.
+Reglas obligatorias:
+- Da la solucion concreta primero, justificacion despues.
+- Incluye al menos UN bloque de accion concreto: codigo, comando, fragmento de diagrama,
+  decision arquitectonica con trade-off explicito, o checklist.
+- Cita patrones, tacticas y atributos de calidad por nombre canonico.
+- Cuantifica cuando sea posible (latencia, throughput, costo, riesgo).
+- Asume que el usuario tiene contexto tecnico; no expliques fundamentos a menos que se pida.
+Estilo: directo, denso, profesional. Sin smalltalk, sin disculpas, sin preguntas socraticas.
+"""
+
+
+def apply_mode_prompt(state: Mapping[str, Any], base_prompt: str) -> str:
+    """Prefija el system prompt del modo activo al `base_prompt` del nodo.
+
+    - Si `state["mode"]` no es `tutor` ni `professional`, devuelve `base_prompt` intacto
+      (default seguro para no romper invocaciones legacy sin modo).
+    - El prefijo se inyecta UNA SOLA VEZ por invocacion (no se persiste en `state.messages`).
+    """
+    mode = (state or {}).get("mode")
+    if mode == "tutor":
+        return f"{TUTOR_SYSTEM_PROMPT}\n\n{base_prompt}"
+    if mode == "professional":
+        return f"{PROFESSIONAL_SYSTEM_PROMPT}\n\n{base_prompt}"
+    return base_prompt

--- a/back/src/graph/resources.py
+++ b/back/src/graph/resources.py
@@ -26,7 +26,7 @@ except Exception:
 
 # LangGraph builder + checkpointer
 from langgraph.graph import StateGraph
-from langgraph.checkpoint.memory import MemorySaver
+from langgraph.store.memory import InMemoryStore
 from src.graph.state import GraphState
 
 # Setup Logging
@@ -112,9 +112,54 @@ class _LazyRetriever:
 
 retriever = _LazyRetriever()
 
-# State-graph builder & checkpointer
-sqlite_saver = MemorySaver()
+# State-graph builder. Checkpointer (AsyncSqliteSaver) y store (InMemoryStore)
+# se inyectan via build_graph() desde el lifespan de FastAPI (ver src/main.py).
 builder = StateGraph(GraphState)
+
+# Holders de la instancia compilada y el store. Se fijan al inicio del lifespan
+# y se consumen via get_graph()/get_store() desde los call-sites.
+_graph_holder: dict = {"instance": None}
+_store_holder: dict = {"instance": None}
+
+
+def set_graph(graph_instance) -> None:
+    """Fija la instancia del grafo compilado. Llamar desde el lifespan."""
+    _graph_holder["instance"] = graph_instance
+
+
+def get_graph():
+    """Devuelve la instancia del grafo compilado. Lanza si lifespan no corrió."""
+    g = _graph_holder["instance"]
+    if g is None:
+        raise RuntimeError(
+            "Graph not initialized. The FastAPI lifespan must run first."
+        )
+    return g
+
+
+def set_store(store_instance) -> None:
+    """Fija la instancia del Store cross-thread. Llamar desde el lifespan."""
+    _store_holder["instance"] = store_instance
+
+
+def get_store():
+    """Devuelve el Store cross-thread. Lanza si lifespan no corrio."""
+    s = _store_holder["instance"]
+    if s is None:
+        raise RuntimeError(
+            "Store not initialized. The FastAPI lifespan must run first."
+        )
+    return s
+
+
+def make_inmemory_store() -> InMemoryStore:
+    """Factory del Store cross-thread.
+
+    InMemoryStore es ephemeral por proceso. Cuando LangGraph publique un
+    backend SQLite oficial para Store (o se decida adoptar
+    `langgraph-checkpoint-postgres` tambien para Store), reemplazar aqui.
+    """
+    return InMemoryStore()
 
 # Sesión HTTP con retries y timeouts
 def _make_http() -> requests.Session:

--- a/back/src/graph/schemas/profile.py
+++ b/back/src/graph/schemas/profile.py
@@ -1,0 +1,74 @@
+"""Esquemas Pydantic para perfilado de usuario.
+
+Reutilizado por:
+- GraphState.user_profile (F2-T1) - tipado documental de la estructura esperada.
+- Shadow Agent / Profile Evaluator (F3-T2) - serializacion con structured_output.
+- Cliente HTTP profile_sync (F3-T5) - payload hacia el Backend Negocio.
+"""
+from __future__ import annotations
+from typing import Dict, List, Optional
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class ConceptScore(BaseModel):
+    """Concepto evaluado con su nivel de dominio (0..1)."""
+
+    name: str = Field(..., description="Nombre canonico del concepto.")
+    mastery: float = Field(..., ge=0.0, le=1.0, description="Dominio en [0,1].")
+    evidence: Optional[str] = Field(
+        None, description="Cita corta del turno que respalda el score."
+    )
+
+
+class UserProfileSchema(BaseModel):
+    """Perfil tecnico del usuario, snapshot del ultimo turno evaluado."""
+
+    user_id: str
+    strengths: List[str] = Field(default_factory=list)
+    weaknesses: List[str] = Field(default_factory=list)
+    evaluated_concepts: List[ConceptScore] = Field(default_factory=list)
+    confidence: float = Field(0.0, ge=0.0, le=1.0)
+
+    @field_validator("strengths", "weaknesses")
+    @classmethod
+    def _strip_empties(cls, v: List[str]) -> List[str]:
+        return [s for s in (v or []) if s and s.strip()]
+
+
+class UserProfileEvaluation(BaseModel):
+    """Salida de una evaluacion del Shadow Agent en un turno (F3-T1).
+
+    Diferente de `UserProfileSchema` (que es el perfil persistido). Esta
+    estructura es la que produce el evaluador via `llm.with_structured_output`
+    y se mergea contra el perfil previo antes de escribir al Store / Negocio.
+
+    Ejemplo:
+        UserProfileEvaluation(
+            strengths=[ConceptScore(name="Modularidad", mastery=0.85)],
+            weaknesses=[ConceptScore(name="Caching", mastery=0.30)],
+            evaluated_concepts=[
+                ConceptScore(name="Modularidad", mastery=0.85, evidence="..."),
+                ConceptScore(name="Caching", mastery=0.30, evidence="..."),
+            ],
+            confidence=0.7,
+            delta_from_previous={"Modularidad": 0.15, "Caching": -0.05},
+        )
+    """
+
+    strengths: List[ConceptScore] = Field(default_factory=list)
+    weaknesses: List[ConceptScore] = Field(default_factory=list)
+    evaluated_concepts: List[ConceptScore] = Field(default_factory=list)
+    confidence: float = Field(0.0, ge=0.0, le=1.0)
+    delta_from_previous: Dict[str, float] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _non_empty_when_confident(self):
+        """Si la confianza es >= 0.5, al menos una de las listas debe traer
+        contenido. Una eval con alta confianza pero todo vacio es ruido."""
+        if self.confidence >= 0.5:
+            if not (self.strengths or self.weaknesses or self.evaluated_concepts):
+                raise ValueError(
+                    "When confidence >= 0.5, at least one of "
+                    "strengths/weaknesses/evaluated_concepts must be non-empty."
+                )
+        return self

--- a/back/src/graph/services/decay.py
+++ b/back/src/graph/services/decay.py
@@ -1,0 +1,90 @@
+"""Curva de olvido (Ebbinghaus simplificada) para perfilado (F3-T4).
+
+Formula: mastery_t = mastery_0 * exp(-decay_rate * delta_days)
+
+- El Store guarda `mastery_0` (observacion mas reciente del Shadow Agent).
+- La hidratacion en `boot_node` aplica decay sobre la copia que va al
+  `state.user_profile`. El valor original NUNCA se sobrescribe en el Store.
+- `decay_rate` por concepto override > env DECAY_RATE_DEFAULT (default 0.05).
+"""
+from __future__ import annotations
+
+import math
+import os
+from datetime import datetime, timezone
+from typing import Optional
+
+DECAY_RATE_DEFAULT = float(os.getenv("DECAY_RATE_DEFAULT", "0.05"))
+
+
+def _parse_iso(value) -> Optional[datetime]:
+    """Parsea ISO 8601 a datetime UTC. Devuelve None si invalido."""
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    try:
+        s = str(value).rstrip("Z")
+        dt = datetime.fromisoformat(s)
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return None
+
+
+def apply_forgetting_curve(
+    concept: dict,
+    now: Optional[datetime] = None,
+    default_decay_rate: float = DECAY_RATE_DEFAULT,
+) -> dict:
+    """Funcion pura: devuelve un dict NUEVO con `mastery` decayed.
+
+    - Conserva todos los campos originales (incluyendo `last_seen_at`).
+    - Anade `mastery_original` (referencia inmutable a mastery_0).
+    - Si `last_seen_at` falta o es invalido, no aplica decay.
+    - `delta_days` se trunca a 0 si es negativo (lecturas en el pasado / clock skew).
+    """
+    out = dict(concept or {})
+    try:
+        mastery_0 = float(out.get("mastery") or 0.0)
+    except (TypeError, ValueError):
+        mastery_0 = 0.0
+    out["mastery_original"] = mastery_0
+
+    last_seen = _parse_iso(out.get("last_seen_at") or out.get("lastSeenAt"))
+    if last_seen is None:
+        return out
+
+    now = now or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+
+    delta_days = max(0.0, (now - last_seen).total_seconds() / 86400.0)
+    try:
+        rate = float(out.get("decay_rate") or default_decay_rate)
+    except (TypeError, ValueError):
+        rate = default_decay_rate
+
+    decayed = mastery_0 * math.exp(-rate * delta_days)
+    out["mastery"] = round(decayed, 4)
+    out["delta_days"] = round(delta_days, 4)
+    return out
+
+
+def apply_decay_to_profile(
+    profile: dict,
+    now: Optional[datetime] = None,
+    default_decay_rate: float = DECAY_RATE_DEFAULT,
+) -> dict:
+    """Aplica `apply_forgetting_curve` a cada elemento de `evaluated_concepts`.
+
+    Devuelve una COPIA del perfil con conceptos decayed; no muta el original.
+    """
+    if not profile:
+        return profile or {}
+    out = dict(profile)
+    concepts = profile.get("evaluated_concepts") or []
+    out["evaluated_concepts"] = [
+        apply_forgetting_curve(c, now=now, default_decay_rate=default_decay_rate)
+        for c in concepts
+    ]
+    return out

--- a/back/src/graph/state.py
+++ b/back/src/graph/state.py
@@ -1,5 +1,5 @@
 
-from typing import Annotated, Literal, List, Dict, Any
+from typing import Annotated, Literal, List, Dict, Any, Optional
 from typing_extensions import TypedDict
 from langgraph.graph.message import add_messages
 from langchain_core.messages import AnyMessage
@@ -116,7 +116,25 @@ class GraphState(TypedDict):
     messages: Annotated[list[AnyMessage], add_messages]
     userQuestion: str
     localQuestion: str
-    
+
+    # ===== Modo de interaccion (F2-T1) =====
+    # Modo activo del turno: "tutor" (pedagogico, socratico) o "professional"
+    # (consultor senior, soluciones directas). Default: "professional".
+    mode: Literal["tutor", "professional"]
+    # Sugerencia de modo emitida por classifier_node (F2-T4) cuando la intencion
+    # del usuario coincide con un modo distinto al actual. None si no aplica.
+    mode_suggestion: Optional[Literal["tutor", "professional"]]
+    # Identidad estable del usuario (no confundir con user_id_for_prefs, que
+    # solo se usa para cargar UserPreference). Este user_id se propaga al
+    # Store cross-thread (F1-T4) y al Shadow Agent (F3-T2).
+    user_id: str
+    # Perfil tecnico hidratado al inicio del turno (F3-T3). Forma libre,
+    # compatible con UserProfileSchema en src/graph/schemas/profile.py.
+    user_profile: dict
+    # F3-T2: contador de turnos desde el ultimo Shadow Agent eval.
+    # Se incrementa en boot_node y se resetea a 0 en unifier al disparar.
+    turn_count_since_eval: int
+
     # Flags de visita
     hasVisitedInvestigator: bool
     hasVisitedEvaluator: bool

--- a/back/src/graph/workflow.py
+++ b/back/src/graph/workflow.py
@@ -1,8 +1,13 @@
 
+import logging
+from datetime import datetime, timezone
+
 from langgraph.graph import START, END
 
 from src.graph.state import GraphState
-from src.graph.resources import sqlite_saver, builder
+from src.graph.resources import builder, get_store
+from src.graph.services.decay import apply_decay_to_profile
+from src.services.profile_sync import fetch_profile_from_negocio
 
 from src.graph.nodes.context_loader import context_loader_node
 from src.graph.nodes.classifier import classifier_node
@@ -30,11 +35,55 @@ _SUPPORTED_QAS = supported_qas()
 _STYLE_QA_NODE_NAMES = {style_node_name_for_qa(qa) for qa in _SUPPORTED_QAS}
 _TACTICS_QA_NODE_NAMES = {tactics_node_name_for_qa(qa) for qa in _SUPPORTED_QAS}
 
-def boot_node(state: GraphState) -> GraphState:
-    """Resetea banderas y buffers al inicio de cada turno (sin borrar last_asr)."""
+_boot_log = logging.getLogger("boot")
+
+
+async def boot_node(state: GraphState) -> GraphState:
+    """Reset banderas y buffers + hidratacion del perfil del usuario (F3-T3 / F3-T6)."""
     _idx = state.get("intake_current_field")
+    user_id = (state.get("user_id") or "").strip()
+    user_profile: dict = {}
+
+    if user_id:
+        try:
+            store = get_store()
+            ns = ("user", user_id, "profile")
+            item = await store.aget(ns, key="profile")
+            if item is None:
+                remote = await fetch_profile_from_negocio(user_id)
+                if remote:
+                    await store.aput(ns, key="profile", value=remote)
+                    user_profile = apply_decay_to_profile(remote)
+                    _boot_log.info(
+                        "boot_node hydrated from Negocio user_id=%s concepts=%d",
+                        user_id,
+                        len(remote.get("evaluated_concepts") or []),
+                    )
+                else:
+                    empty = {
+                        "user_id": user_id,
+                        "strengths": [],
+                        "weaknesses": [],
+                        "evaluated_concepts": [],
+                        "confidence": 0.0,
+                        "delta_from_previous": {},
+                        "updated_at": datetime.now(timezone.utc).isoformat(),
+                    }
+                    await store.aput(ns, key="profile", value=empty)
+                    user_profile = empty
+            else:
+                user_profile = apply_decay_to_profile(item.value or {})
+        except Exception:
+            _boot_log.exception(
+                "boot_node profile hydration failed for user_id=%s", user_id
+            )
+            user_profile = {}
+
     return {
         **state,
+        "user_profile": user_profile,
+        # F3-T2: incrementa contador para el Shadow Agent (cadencia).
+        "turn_count_since_eval": (state.get("turn_count_since_eval") or 0) + 1,
         "hasVisitedInvestigator": False,
         "hasVisitedEvaluator": False,
         "hasVisitedASR": False,
@@ -153,4 +202,12 @@ for node_name in sorted(_TACTICS_QA_NODE_NAMES):
 
 builder.add_edge("unifier", END)
 
-graph = builder.compile(checkpointer=sqlite_saver)
+
+def build_graph(checkpointer, store=None):
+    """Compila el grafo con el checkpointer (AsyncSqliteSaver) y el store
+    (InMemoryStore) inyectados desde el lifespan de FastAPI.
+
+    Llamar una sola vez al startup. La instancia resultante se publica via
+    set_graph() en src/graph/resources.py para que get_graph() la exponga.
+    """
+    return builder.compile(checkpointer=checkpointer, store=store)

--- a/back/src/main.py
+++ b/back/src/main.py
@@ -59,7 +59,14 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 
 from langchain_core.messages import HumanMessage
-from src.graph import graph
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+from src.graph import (
+    build_graph,
+    get_graph,
+    set_graph,
+    set_store,
+    make_inmemory_store,
+)
 from src.rag_agent import create_or_load_vectorstore
 from src.memory import (
     init as memory_init,
@@ -86,13 +93,21 @@ def detect_lang(q: str) -> str:
 # ===================== Lifespan ==========================
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    try:
-        create_or_load_vectorstore()
-        print("[startup] RAG listo")
-    except Exception as e:
-        print(f"[startup] RAG init omitido: {e}")
-    yield
-    print("[shutdown] Cerrando app...")
+    db_path = Path(__file__).resolve().parent.parent / "state_db" / "graph_checkpoints.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    async with AsyncSqliteSaver.from_conn_string(str(db_path)) as saver:
+        store = make_inmemory_store()
+        compiled = build_graph(saver, store=store)
+        set_graph(compiled)
+        set_store(store)
+        try:
+            create_or_load_vectorstore()
+            print("[startup] RAG listo")
+        except Exception as e:
+            print(f"[startup] RAG init omitido: {e}")
+        print(f"[startup] Checkpointer listo: {db_path}")
+        yield
+        print("[shutdown] Cerrando app...")
 
 # Una sola instancia de FastAPI
 app = FastAPI(title="ArquIA API", lifespan=lifespan)
@@ -562,6 +577,8 @@ async def message(
     request: Request,
     message: str = Form(...),
     session_id: str = Form(...),
+    mode: str = Form(None),
+    user_id: str = Form(None),
     image1: Optional[UploadFile] = File(None),
     image2: Optional[UploadFile] = File(None),
     project_id: Optional[str] = Form(None),
@@ -571,8 +588,17 @@ async def message(
     if not session_id:
         raise HTTPException(status_code=400, detail="No session ID provided")
 
-    # Identidad simple por sesión
-    user_id    = request.headers.get("X-User-Id") or session_id
+    # F2-T2: validacion de mode (default seguro: professional).
+    if mode is None or mode == "":
+        mode = "professional"
+    if mode not in ("tutor", "professional"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid mode: {mode!r}. Use 'tutor' or 'professional'.",
+        )
+
+    # F2-T2: user_id estable. Prioridad: Form > X-User-Id > session_id.
+    user_id = (user_id or request.headers.get("X-User-Id") or session_id).strip()
     authorization_header = (request.headers.get("Authorization") or "").strip()
     authorization_parts = authorization_header.split()
     api_token = (
@@ -722,7 +748,7 @@ async def message(
 
     # --- Limpieza parcial del estado (sin borrar historial persistente del grafo) ---
     try:
-        graph.update_state(config, {"values": {
+        get_graph().update_state(config, {"values": {
             "endMessage": "",
 
             "diagram": {},  # FIX: dict vacío, no None
@@ -741,6 +767,11 @@ async def message(
         "messages": turn_messages,
         "userQuestion": message,
         "localQuestion": "",
+        # F2-T1 / F2-T2: campos de modo y perfilado.
+        "mode": mode,
+        "mode_suggestion": None,  # lo rellena classifier en F2-T4
+        "user_id": user_id,
+        "user_profile": {},  # se hidratara en F3-T3 (boot_node)
         "hasVisitedInvestigator": False,
         "hasVisitedEvaluator": False,
         "hasVisitedASR": False,
@@ -798,7 +829,7 @@ async def message(
             # that node's return dict), with no intermediate token/sub-chain events.
             # This avoids the serialisation overhead of astream_events(version="v2")
             # which copies the full state on every LLM token.
-            async for chunk in graph.astream(input_state, config, stream_mode="updates"):
+            async for chunk in get_graph().astream(input_state, config, stream_mode="updates"):
                 for node_name, node_output in chunk.items():
                     if not isinstance(node_output, dict):
                         continue
@@ -841,6 +872,9 @@ async def message(
                             "message_id": _message_id,
                             "thread_id":  _thread_id,
                             "suggestions": node_output.get("suggestions", []),
+                            # F2-T4: modo activo y sugerencia de cambio.
+                            "mode":             node_output.get("mode", "professional"),
+                            "mode_suggestion":  node_output.get("mode_suggestion"),
                         })
                         yield _sse(payload)
 

--- a/back/src/services/diagram_export.py
+++ b/back/src/services/diagram_export.py
@@ -330,7 +330,8 @@ def export_workflow(*, fmt: str = "dot") -> str | bytes:
     """
     # Lazy import to avoid pulling LangGraph at module-import time,
     # which is important for testing with mocks.
-    from src.graph import graph as compiled_graph  # noqa: E402
+    from src.graph import get_graph  # noqa: E402
+    compiled_graph = get_graph()
 
     model = extract_from_langgraph(compiled_graph)
     dot = render_dot(model)

--- a/back/src/services/profile_sync.py
+++ b/back/src/services/profile_sync.py
@@ -1,0 +1,263 @@
+"""Cliente HTTP que sincroniza el perfil de usuario al Backend Negocio (F3-T5).
+
+Disparado tras un `store.aput(...)` exitoso en el Shadow Agent. Reintenta
+con backoff exponencial (3 intentos: 1s, 2s, 4s). Si Negocio esta caido,
+la app IA sigue funcionando con el perfil del Store local intacto.
+
+Configuracion via env:
+- BUSINESS_API_BASE_URL     (default http://localhost:3000)
+- BUSINESS_API_PROFILE_PATH (default /internal/users/{userId}/profile)
+- INTERNAL_API_TOKEN        (sin default; vacio -> sync deshabilitado)
+- PROFILE_SYNC_ENABLED      (default true)
+- PROFILE_SYNC_TIMEOUT      (segundos por intento, default 15)
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+import httpx
+
+log = logging.getLogger("profile_sync")
+
+
+def _env_base_url() -> str:
+    return os.getenv("BUSINESS_API_BASE_URL", "http://localhost:3000").rstrip("/")
+
+
+def _env_path_template() -> str:
+    return os.getenv("BUSINESS_API_PROFILE_PATH", "/internal/users/{userId}/profile")
+
+
+def _env_token() -> str:
+    return (os.getenv("INTERNAL_API_TOKEN") or "").strip()
+
+
+def _env_enabled() -> bool:
+    return (os.getenv("PROFILE_SYNC_ENABLED", "true") or "true").lower() == "true"
+
+
+def _env_timeout() -> float:
+    try:
+        return float(os.getenv("PROFILE_SYNC_TIMEOUT", "15"))
+    except (TypeError, ValueError):
+        return 15.0
+
+
+def _scale_to_business(mastery_0_to_1) -> float:
+    """0-1 (interno) -> 0-100 (contrato Negocio EvaluatedConcept)."""
+    try:
+        v = float(mastery_0_to_1)
+    except (TypeError, ValueError):
+        v = 0.0
+    return round(max(0.0, min(1.0, v)) * 100.0, 2)
+
+
+def _to_business_payload(merged: dict) -> dict:
+    """Transforma el dict mergeado del Store al body camelCase para Negocio.
+
+    Mapeo:
+    - user_id            -> userId (path arg, NO en body)
+    - strengths          -> strengths (lista de strings, igual)
+    - weaknesses         -> weaknesses
+    - evaluated_concepts -> evaluatedConcepts (mastery 0-100; lastSeenAt camelCase)
+    - confidence         -> confidence
+    - delta_from_previous -> deltaFromPrevious
+    - updated_at         -> updatedAt
+
+    `mastery_original` (si existe) tiene prioridad sobre `mastery` para
+    evitar enviar el valor decayed-en-lectura.
+    """
+    merged = merged or {}
+    concepts_out = []
+    for c in (merged.get("evaluated_concepts") or []):
+        if not isinstance(c, dict):
+            continue
+        mastery_raw = c.get("mastery_original")
+        if mastery_raw is None:
+            mastery_raw = c.get("mastery")
+        item = {
+            "name": c.get("name", ""),
+            "mastery": _scale_to_business(mastery_raw or 0.0),
+        }
+        if c.get("last_seen_at"):
+            item["lastSeenAt"] = c["last_seen_at"]
+        if c.get("decay_rate") is not None:
+            try:
+                item["decayRate"] = float(c["decay_rate"])
+            except (TypeError, ValueError):
+                pass
+        if c.get("evidence"):
+            item["evidence"] = c["evidence"]
+        concepts_out.append(item)
+
+    return {
+        "strengths": list(merged.get("strengths") or []),
+        "weaknesses": list(merged.get("weaknesses") or []),
+        "evaluatedConcepts": concepts_out,
+        "confidence": float(merged.get("confidence") or 0.0),
+        "deltaFromPrevious": dict(merged.get("delta_from_previous") or {}),
+        "updatedAt": merged.get("updated_at") or "",
+    }
+
+
+def _from_business_payload(data: dict) -> dict:
+    """Convierte la respuesta camelCase de Negocio al formato snake_case del Store.
+
+    Inverso de _to_business_payload. Usado por fetch_profile_from_negocio (F3-T6)
+    para hidratar el InMemoryStore tras un reinicio del proceso IA.
+
+    Conversiones:
+    - evaluatedConcepts -> evaluated_concepts  (mastery 0-100 -> 0-1)
+    - lastSeenAt        -> last_seen_at
+    - decayRate         -> decay_rate
+    - userId            -> user_id
+
+    Campos que Negocio no persiste (confidence, delta_from_previous) se
+    inicializan con valores neutros.
+    """
+    data = data or {}
+    concepts_out = []
+    for c in (data.get("evaluatedConcepts") or []):
+        if not isinstance(c, dict):
+            continue
+        item: dict = {"name": c.get("name", "")}
+        try:
+            item["mastery"] = round(float(c.get("mastery") or 0.0) / 100.0, 4)
+        except (TypeError, ValueError):
+            item["mastery"] = 0.0
+        if c.get("lastSeenAt"):
+            item["last_seen_at"] = c["lastSeenAt"]
+        if c.get("decayRate") is not None:
+            try:
+                item["decay_rate"] = float(c["decayRate"])
+            except (TypeError, ValueError):
+                pass
+        concepts_out.append(item)
+
+    return {
+        "user_id": data.get("userId", ""),
+        "strengths": list(data.get("strengths") or []),
+        "weaknesses": list(data.get("weaknesses") or []),
+        "evaluated_concepts": concepts_out,
+        # Negocio no persiste estos campos; se inicializan neutros.
+        "confidence": 0.0,
+        "delta_from_previous": {},
+        "updated_at": data.get("updatedAt") or "",
+    }
+
+
+async def fetch_profile_from_negocio(user_id: str) -> dict | None:
+    """GET del perfil desde el Backend Negocio para hidratacion inversa (F3-T6).
+
+    Llamado por boot_node cuando el InMemoryStore no tiene perfil para el
+    user_id (primer acceso tras un reinicio del proceso — Store ephemeral).
+
+    Ruta: GET <BUSINESS_API_BASE_URL><BUSINESS_API_PROFILE_PATH>
+    Auth: X-Internal-Token (mismo token que usa sync_profile para el PUT).
+
+    Devuelve el perfil en formato snake_case del Store, o None si:
+    - PROFILE_SYNC_ENABLED=false
+    - INTERNAL_API_TOKEN vacio
+    - user_id vacio
+    - Negocio devuelve 404 (perfil aun no existe) o cualquier error de red/timeout
+
+    NUNCA lanza al caller.
+    """
+    if not _env_enabled():
+        log.debug("fetch_profile skipped: PROFILE_SYNC_ENABLED=false")
+        return None
+    user_id = (user_id or "").strip()
+    if not user_id:
+        return None
+    token = _env_token()
+    if not token:
+        log.warning("fetch_profile skipped: INTERNAL_API_TOKEN empty")
+        return None
+
+    url = _env_base_url() + _env_path_template().replace("{userId}", user_id)
+    timeout = _env_timeout()
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.get(url, headers={"X-Internal-Token": token})
+        if resp.status_code == 200:
+            profile = _from_business_payload(resp.json())
+            log.info(
+                "fetch_profile ok user_id=%s concepts=%d",
+                user_id,
+                len(profile.get("evaluated_concepts") or []),
+            )
+            return profile
+        if resp.status_code == 404:
+            log.debug(
+                "fetch_profile 404 user_id=%s (no profile in Negocio yet)", user_id
+            )
+            return None
+        log.warning(
+            "fetch_profile status=%d user_id=%s body=%s",
+            resp.status_code, user_id, (resp.text or "")[:200],
+        )
+        return None
+    except (httpx.RequestError, httpx.TimeoutException) as exc:
+        log.warning("fetch_profile error user_id=%s: %s", user_id, exc)
+        return None
+
+
+async def sync_profile(user_id: str, merged_profile: dict, *, max_attempts: int = 3) -> bool:
+    """PUT del perfil al Backend Negocio con retry exponencial.
+
+    Devuelve True si algun intento fue 2xx; False si todos fallaron o se omitio.
+    NUNCA lanza al caller (criterio del backlog: app IA sigue corriendo).
+    """
+    if not _env_enabled():
+        log.debug("profile_sync skipped: PROFILE_SYNC_ENABLED=false")
+        return False
+    user_id = (user_id or "").strip()
+    if not user_id:
+        log.warning("profile_sync skipped: empty user_id")
+        return False
+    token = _env_token()
+    if not token:
+        log.warning("profile_sync skipped: INTERNAL_API_TOKEN empty")
+        return False
+
+    url = _env_base_url() + _env_path_template().replace("{userId}", str(user_id))
+    payload = _to_business_payload(merged_profile)
+    timeout = _env_timeout()
+
+    backoff = 1.0
+    for attempt in range(1, max_attempts + 1):
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.put(
+                    url,
+                    json=payload,
+                    headers={
+                        "X-Internal-Token": token,
+                        "Content-Type": "application/json",
+                    },
+                )
+            if 200 <= resp.status_code < 300:
+                log.info(
+                    "profile_sync ok user_id=%s attempt=%d status=%d",
+                    user_id, attempt, resp.status_code,
+                )
+                return True
+            log.warning(
+                "profile_sync attempt=%d status=%d body=%s",
+                attempt, resp.status_code, (resp.text or "")[:200],
+            )
+        except (httpx.RequestError, httpx.TimeoutException) as exc:
+            log.warning("profile_sync attempt=%d error=%s", attempt, exc)
+
+        if attempt < max_attempts:
+            await asyncio.sleep(backoff)
+            backoff *= 2
+
+    log.error(
+        "profile_sync gave up after %d attempts for user_id=%s url=%s",
+        max_attempts, user_id, url,
+    )
+    return False

--- a/back/tests/test_boot_hydration.py
+++ b/back/tests/test_boot_hydration.py
@@ -1,0 +1,235 @@
+"""Tests F3-T3 / F3-T6: hidratacion del perfil en boot_node."""
+import asyncio
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.graph.workflow import boot_node
+
+
+# ---- helpers -------------------------------------------------------------
+
+class _FakeStoreItem:
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeStore:
+    def __init__(self, initial=None):
+        self._data = dict(initial or {})
+
+    async def aget(self, ns, key):
+        if (ns, key) in self._data:
+            return _FakeStoreItem(self._data[(ns, key)])
+        return None
+
+    async def aput(self, ns, key, value):
+        self._data[(ns, key)] = value
+
+
+def _patch_store(monkeypatch, store):
+    """Sustituye el holder de Store en src.graph.resources."""
+    from src.graph import resources
+
+    monkeypatch.setattr(resources, "_store_holder", {"instance": store})
+
+
+def _base_state(**overrides):
+    base = {
+        "user_id": "u1",
+        "turn_count_since_eval": 0,
+        "messages": [],
+    }
+    base.update(overrides)
+    return base
+
+
+# ---- tests ---------------------------------------------------------------
+
+def test_boot_creates_empty_profile_when_missing(monkeypatch):
+    store = _FakeStore()
+    _patch_store(monkeypatch, store)
+
+    out = asyncio.run(boot_node(_base_state(user_id="u1")))
+
+    assert out["user_profile"]["user_id"] == "u1"
+    assert out["user_profile"]["evaluated_concepts"] == []
+    assert out["user_profile"]["strengths"] == []
+    assert out["user_profile"]["weaknesses"] == []
+    # Counter incremented
+    assert out["turn_count_since_eval"] == 1
+    # And the empty profile was written to the store for future reads.
+    persisted = asyncio.run(store.aget(("user", "u1", "profile"), "profile"))
+    assert persisted is not None
+    assert persisted.value["user_id"] == "u1"
+
+
+def test_boot_hydrates_existing_profile_with_decay(monkeypatch):
+    last_seen = (datetime.now(timezone.utc) - timedelta(days=20)).isoformat()
+    pre = {
+        "user_id": "u1",
+        "strengths": ["Modularidad"],
+        "weaknesses": [],
+        "evaluated_concepts": [
+            {"name": "Modularidad", "mastery": 1.0, "last_seen_at": last_seen},
+        ],
+        "confidence": 0.7,
+    }
+    store = _FakeStore(initial={(("user", "u1", "profile"), "profile"): pre})
+    _patch_store(monkeypatch, store)
+
+    out = asyncio.run(boot_node(_base_state(user_id="u1", turn_count_since_eval=3)))
+
+    profile = out["user_profile"]
+    concept = profile["evaluated_concepts"][0]
+    # Decay applied on read
+    assert concept["mastery"] < 1.0
+    # Original preserved as reference
+    assert concept["mastery_original"] == 1.0
+    # Strengths preserved
+    assert "Modularidad" in profile["strengths"]
+    # Counter incremented
+    assert out["turn_count_since_eval"] == 4
+
+
+def test_boot_does_not_mutate_store_value(monkeypatch):
+    """Decay en lectura NO debe alterar el valor persistido."""
+    last_seen = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    pre = {
+        "user_id": "u1",
+        "strengths": [],
+        "weaknesses": [],
+        "evaluated_concepts": [
+            {"name": "X", "mastery": 1.0, "last_seen_at": last_seen}
+        ],
+    }
+    store = _FakeStore(initial={(("user", "u1", "profile"), "profile"): pre})
+    _patch_store(monkeypatch, store)
+
+    asyncio.run(boot_node(_base_state(user_id="u1")))
+    # Despues de la hidratacion, el Store sigue con mastery=1.0 sin decay
+    persisted = asyncio.run(store.aget(("user", "u1", "profile"), "profile"))
+    assert persisted.value["evaluated_concepts"][0]["mastery"] == 1.0
+
+
+def test_boot_empty_user_id_skips_hydration(monkeypatch):
+    store = _FakeStore()
+    _patch_store(monkeypatch, store)
+
+    out = asyncio.run(boot_node(_base_state(user_id="")))
+    assert out["user_profile"] == {}
+    # Nothing written
+    assert asyncio.run(store.aget(("user", "", "profile"), "profile")) is None
+
+
+# ---- F3-T6: hidratacion inversa desde Negocio ----------------------------
+
+def test_boot_hydrates_from_negocio_on_store_miss(monkeypatch):
+    """Store vacio + Negocio devuelve perfil → se hidrata el Store y el estado."""
+    store = _FakeStore()
+    _patch_store(monkeypatch, store)
+
+    remote_profile = {
+        "user_id": "u1",
+        "strengths": ["SOLID"],
+        "weaknesses": ["Testing"],
+        "evaluated_concepts": [
+            {"name": "SOLID", "mastery": 0.8, "last_seen_at": datetime.now(timezone.utc).isoformat()},
+        ],
+        "confidence": 0.0,
+        "delta_from_previous": {},
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    with patch(
+        "src.graph.workflow.fetch_profile_from_negocio",
+        new=AsyncMock(return_value=remote_profile),
+    ):
+        out = asyncio.run(boot_node(_base_state(user_id="u1")))
+
+    # El estado tiene el perfil remoto (con decay aplicado)
+    assert out["user_profile"]["strengths"] == ["SOLID"]
+    assert out["user_profile"]["weaknesses"] == ["Testing"]
+    assert len(out["user_profile"]["evaluated_concepts"]) == 1
+    # El Store fue hidratado con los datos remotos
+    persisted = asyncio.run(store.aget(("user", "u1", "profile"), "profile"))
+    assert persisted is not None
+    assert persisted.value["strengths"] == ["SOLID"]
+
+
+def test_boot_creates_empty_when_negocio_returns_none(monkeypatch):
+    """Store vacio + Negocio devuelve None → perfil vacio creado (comportamiento anterior)."""
+    store = _FakeStore()
+    _patch_store(monkeypatch, store)
+
+    with patch(
+        "src.graph.workflow.fetch_profile_from_negocio",
+        new=AsyncMock(return_value=None),
+    ):
+        out = asyncio.run(boot_node(_base_state(user_id="u1")))
+
+    assert out["user_profile"]["evaluated_concepts"] == []
+    assert out["user_profile"]["strengths"] == []
+
+
+def test_boot_does_not_call_negocio_when_store_has_profile(monkeypatch):
+    """Store ya tiene perfil → NO se llama a fetch_profile_from_negocio."""
+    pre = {
+        "user_id": "u1",
+        "strengths": ["Patrones"],
+        "weaknesses": [],
+        "evaluated_concepts": [],
+        "confidence": 0.5,
+    }
+    store = _FakeStore(initial={(("user", "u1", "profile"), "profile"): pre})
+    _patch_store(monkeypatch, store)
+
+    mock_fetch = AsyncMock(return_value=None)
+    with patch("src.graph.workflow.fetch_profile_from_negocio", new=mock_fetch):
+        asyncio.run(boot_node(_base_state(user_id="u1")))
+
+    mock_fetch.assert_not_called()
+
+
+def test_boot_falls_back_to_empty_when_negocio_raises(monkeypatch):
+    """Si fetch_profile_from_negocio lanza excepcion inesperada → perfil vacio, no crash."""
+    store = _FakeStore()
+    _patch_store(monkeypatch, store)
+
+    async def _boom(user_id):
+        raise RuntimeError("network error")
+
+    with patch("src.graph.workflow.fetch_profile_from_negocio", new=_boom):
+        # boot_node captura la excepcion interna y devuelve user_profile={}
+        out = asyncio.run(boot_node(_base_state(user_id="u1")))
+
+    assert out["user_profile"] == {}
+    # El turno no se rompio
+    assert out["turn_count_since_eval"] == 1
+
+
+# --------------------------------------------------------------------------
+
+def test_boot_resets_turn_buffers(monkeypatch):
+    store = _FakeStore()
+    _patch_store(monkeypatch, store)
+
+    state = _base_state(
+        user_id="u1",
+        hasVisitedInvestigator=True,
+        hasVisitedEvaluator=True,
+        endMessage="leftover",
+        requested_nodes=["x"],
+        pending_nodes=["y"],
+        completed_nodes=["z"],
+        diagram={"ok": True},
+    )
+    out = asyncio.run(boot_node(state))
+    assert out["hasVisitedInvestigator"] is False
+    assert out["hasVisitedEvaluator"] is False
+    assert out["endMessage"] == ""
+    assert out["requested_nodes"] == []
+    assert out["pending_nodes"] == []
+    assert out["completed_nodes"] == []
+    assert out["diagram"] == {}

--- a/back/tests/test_decay.py
+++ b/back/tests/test_decay.py
@@ -1,0 +1,121 @@
+"""Tests F3-T4: curva de olvido (apply_forgetting_curve, apply_decay_to_profile)."""
+import math
+from datetime import datetime, timezone, timedelta
+
+from src.graph.services.decay import (
+    apply_forgetting_curve,
+    apply_decay_to_profile,
+    DECAY_RATE_DEFAULT,
+)
+
+
+def test_no_last_seen_returns_unchanged_mastery():
+    c = {"name": "X", "mastery": 0.8}
+    out = apply_forgetting_curve(c, now=datetime.now(timezone.utc))
+    assert out["mastery"] == 0.8
+    assert out["mastery_original"] == 0.8
+
+
+def test_delta_days_zero_no_decay():
+    now = datetime(2026, 4, 29, tzinfo=timezone.utc)
+    c = {"name": "X", "mastery": 0.9, "last_seen_at": now.isoformat()}
+    out = apply_forgetting_curve(c, now=now)
+    assert out["mastery"] == 0.9
+    assert out["delta_days"] == 0.0
+
+
+def test_delta_days_30_decay_default_rate():
+    now = datetime(2026, 4, 29, tzinfo=timezone.utc)
+    last = now - timedelta(days=30)
+    c = {"name": "X", "mastery": 1.0, "last_seen_at": last.isoformat()}
+    out = apply_forgetting_curve(c, now=now)
+    expected = 1.0 * math.exp(-0.05 * 30)  # ~0.2231
+    assert abs(out["mastery"] - round(expected, 4)) < 1e-4
+    assert out["mastery_original"] == 1.0
+
+
+def test_per_concept_decay_rate_overrides_default():
+    now = datetime(2026, 4, 29, tzinfo=timezone.utc)
+    last = now - timedelta(days=30)
+    c = {
+        "name": "X",
+        "mastery": 1.0,
+        "last_seen_at": last.isoformat(),
+        "decay_rate": 0.01,
+    }
+    out = apply_forgetting_curve(c, now=now)
+    expected = math.exp(-0.01 * 30)
+    assert abs(out["mastery"] - round(expected, 4)) < 1e-4
+
+
+def test_negative_delta_clamped_to_zero():
+    now = datetime(2026, 4, 29, tzinfo=timezone.utc)
+    last = now + timedelta(days=5)  # futuro (clock skew)
+    c = {"name": "X", "mastery": 0.7, "last_seen_at": last.isoformat()}
+    out = apply_forgetting_curve(c, now=now)
+    assert out["mastery"] == 0.7
+    assert out["delta_days"] == 0.0
+
+
+def test_lastseenat_camel_case_also_supported():
+    """Compatibilidad con la notacion del contrato OpenAPI (lastSeenAt)."""
+    now = datetime(2026, 4, 29, tzinfo=timezone.utc)
+    last = now - timedelta(days=10)
+    c = {"name": "X", "mastery": 1.0, "lastSeenAt": last.isoformat()}
+    out = apply_forgetting_curve(c, now=now)
+    expected = math.exp(-0.05 * 10)
+    assert abs(out["mastery"] - round(expected, 4)) < 1e-4
+
+
+def test_invalid_lastseenat_returns_unchanged():
+    c = {"name": "X", "mastery": 0.8, "last_seen_at": "garbage-not-a-date"}
+    out = apply_forgetting_curve(c, now=datetime.now(timezone.utc))
+    assert out["mastery"] == 0.8
+
+
+def test_apply_decay_to_profile_processes_all_concepts():
+    now = datetime(2026, 4, 29, tzinfo=timezone.utc)
+    profile = {
+        "user_id": "u1",
+        "evaluated_concepts": [
+            {
+                "name": "A",
+                "mastery": 1.0,
+                "last_seen_at": (now - timedelta(days=10)).isoformat(),
+            },
+            {"name": "B", "mastery": 0.5},
+        ],
+    }
+    out = apply_decay_to_profile(profile, now=now)
+    assert len(out["evaluated_concepts"]) == 2
+    a = out["evaluated_concepts"][0]
+    assert a["mastery"] < 1.0
+    assert a["mastery_original"] == 1.0
+    b = out["evaluated_concepts"][1]
+    assert b["mastery"] == 0.5
+
+
+def test_apply_decay_does_not_mutate_input():
+    now = datetime(2026, 4, 29, tzinfo=timezone.utc)
+    profile = {
+        "evaluated_concepts": [
+            {
+                "name": "A",
+                "mastery": 1.0,
+                "last_seen_at": (now - timedelta(days=30)).isoformat(),
+            }
+        ]
+    }
+    original_mastery = profile["evaluated_concepts"][0]["mastery"]
+    _ = apply_decay_to_profile(profile, now=now)
+    assert profile["evaluated_concepts"][0]["mastery"] == original_mastery
+
+
+def test_apply_decay_to_empty_profile_safe():
+    assert apply_decay_to_profile({}) == {}
+    assert apply_decay_to_profile(None) == {}
+
+
+def test_default_decay_rate_constant():
+    assert isinstance(DECAY_RATE_DEFAULT, float)
+    assert DECAY_RATE_DEFAULT > 0.0

--- a/back/tests/test_mode_prompts.py
+++ b/back/tests/test_mode_prompts.py
@@ -1,0 +1,55 @@
+"""Tests del helper apply_mode_prompt (F2-T3) sin LLM."""
+from src.graph.prompts.mode_prompts import (
+    TUTOR_SYSTEM_PROMPT,
+    PROFESSIONAL_SYSTEM_PROMPT,
+    apply_mode_prompt,
+)
+
+
+def test_tutor_prompt_has_socratic_marker():
+    assert "?" in TUTOR_SYSTEM_PROMPT
+    assert "socratic" in TUTOR_SYSTEM_PROMPT.lower()
+
+
+def test_professional_prompt_has_action_marker():
+    txt = PROFESSIONAL_SYSTEM_PROMPT.lower()
+    assert "directa" in txt or "directo" in txt
+    assert "codigo" in txt or "comando" in txt or "diagrama" in txt
+
+
+def test_apply_mode_prefixes_tutor():
+    base = "BASE_NODE_PROMPT"
+    out = apply_mode_prompt({"mode": "tutor"}, base)
+    assert out.startswith(TUTOR_SYSTEM_PROMPT)
+    assert out.endswith(base)
+
+
+def test_apply_mode_prefixes_professional():
+    base = "BASE_NODE_PROMPT"
+    out = apply_mode_prompt({"mode": "professional"}, base)
+    assert out.startswith(PROFESSIONAL_SYSTEM_PROMPT)
+    assert out.endswith(base)
+
+
+def test_apply_mode_default_safe_when_missing():
+    base = "BASE_NODE_PROMPT"
+    assert apply_mode_prompt({}, base) == base
+    assert apply_mode_prompt({"mode": None}, base) == base
+    assert apply_mode_prompt({"mode": "weird"}, base) == base
+
+
+def test_apply_mode_does_not_mutate_state():
+    state = {"mode": "tutor"}
+    apply_mode_prompt(state, "X")
+    assert state == {"mode": "tutor"}
+
+
+def test_apply_mode_only_one_prefix_per_invocation():
+    """Verifica que invocar dos veces NO acumula el prefijo en el mismo string."""
+    base = "BASE"
+    once = apply_mode_prompt({"mode": "tutor"}, base)
+    twice = apply_mode_prompt({"mode": "tutor"}, base)
+    # Cada invocacion produce el mismo string; el prefijo no se acumula
+    # porque siempre opera sobre `base`, no sobre el resultado anterior.
+    assert once == twice
+    assert once.count(TUTOR_SYSTEM_PROMPT) == 1

--- a/back/tests/test_mode_suggestion.py
+++ b/back/tests/test_mode_suggestion.py
@@ -1,0 +1,44 @@
+"""Tests heuristica de auto-routing de modo (F2-T4)."""
+from src.graph.nodes.classifier import suggest_mode
+
+
+def test_tutor_trigger_explicame_from_professional():
+    assert suggest_mode("Explicame que es un microservicio", "professional") == "tutor"
+
+
+def test_tutor_trigger_no_entiendo():
+    assert suggest_mode("No entiendo el patron CQRS", "professional") == "tutor"
+
+
+def test_professional_trigger_implementa_from_tutor():
+    assert suggest_mode("Dame el codigo para implementar circuit breaker", "tutor") == "professional"
+
+
+def test_professional_trigger_diagrama():
+    assert suggest_mode("Quiero un diagrama de despliegue para microservicios", "tutor") == "professional"
+
+
+def test_no_suggestion_when_already_in_target_mode_tutor():
+    assert suggest_mode("Explicame que es un microservicio", "tutor") is None
+
+
+def test_no_suggestion_when_already_in_target_mode_professional():
+    assert suggest_mode("Dame el codigo para implementar circuit breaker", "professional") is None
+
+
+def test_no_suggestion_when_neutral_message():
+    assert suggest_mode("hola", "professional") is None
+
+
+def test_english_tutor_trigger():
+    assert suggest_mode("explain what is a saga pattern", "professional") == "tutor"
+
+
+def test_english_professional_trigger():
+    assert suggest_mode("give me the code to design the API", "tutor") == "professional"
+
+
+def test_no_suggestion_when_both_signals_balanced():
+    """Si hay 1 trigger en cada lado (ambos 0.5), ninguno supera al otro."""
+    msg = "explicame e implementa"
+    assert suggest_mode(msg, "professional") is None

--- a/back/tests/test_profile_fetch.py
+++ b/back/tests/test_profile_fetch.py
@@ -1,0 +1,171 @@
+"""Tests F3-T6: fetch_profile_from_negocio + _from_business_payload."""
+import asyncio
+
+import pytest
+import httpx
+import respx  # HTTP mock compatible con httpx
+
+from src.services.profile_sync import fetch_profile_from_negocio, _from_business_payload
+
+
+# ---------------------------------------------------------------------------
+# _from_business_payload — conversion camelCase Negocio → snake_case Store
+# ---------------------------------------------------------------------------
+
+def test_from_business_payload_converts_mastery_scale():
+    """mastery 0-100 (Negocio) → 0-1 (Store interno)."""
+    data = {
+        "userId": "abc",
+        "strengths": ["SOLID"],
+        "weaknesses": ["Testing"],
+        "evaluatedConcepts": [
+            {"name": "SOLID", "mastery": 80.0, "lastSeenAt": "2026-04-01T00:00:00Z"},
+        ],
+        "updatedAt": "2026-04-01T00:00:00Z",
+    }
+    result = _from_business_payload(data)
+
+    assert result["user_id"] == "abc"
+    assert result["strengths"] == ["SOLID"]
+    assert result["weaknesses"] == ["Testing"]
+    assert len(result["evaluated_concepts"]) == 1
+    concept = result["evaluated_concepts"][0]
+    assert concept["name"] == "SOLID"
+    assert concept["mastery"] == pytest.approx(0.8, abs=1e-4)
+    assert concept["last_seen_at"] == "2026-04-01T00:00:00Z"
+
+
+def test_from_business_payload_optional_decay_rate():
+    """decayRate presente → se incluye como decay_rate; ausente → se omite."""
+    data = {
+        "evaluatedConcepts": [
+            {"name": "A", "mastery": 50.0, "decayRate": 0.03},
+            {"name": "B", "mastery": 20.0},
+        ],
+    }
+    result = _from_business_payload(data)
+    assert result["evaluated_concepts"][0]["decay_rate"] == pytest.approx(0.03)
+    assert "decay_rate" not in result["evaluated_concepts"][1]
+
+
+def test_from_business_payload_empty_concepts():
+    """Sin evaluatedConcepts → lista vacia, sin crash."""
+    result = _from_business_payload({"evaluatedConcepts": []})
+    assert result["evaluated_concepts"] == []
+
+
+def test_from_business_payload_initializes_neutral_fields():
+    """confidence y delta_from_previous se inicializan neutros (Negocio no los persiste)."""
+    result = _from_business_payload({})
+    assert result["confidence"] == 0.0
+    assert result["delta_from_previous"] == {}
+
+
+def test_from_business_payload_skips_non_dict_concepts():
+    """Conceptos que no son dict se ignoran sin crash."""
+    data = {"evaluatedConcepts": [None, "string", {"name": "X", "mastery": 100.0}]}
+    result = _from_business_payload(data)
+    assert len(result["evaluated_concepts"]) == 1
+    assert result["evaluated_concepts"][0]["name"] == "X"
+
+
+# ---------------------------------------------------------------------------
+# fetch_profile_from_negocio — guards de configuracion
+# ---------------------------------------------------------------------------
+
+def test_fetch_returns_none_when_disabled(monkeypatch):
+    monkeypatch.setenv("PROFILE_SYNC_ENABLED", "false")
+    monkeypatch.setenv("INTERNAL_API_TOKEN", "tok")
+    result = asyncio.run(fetch_profile_from_negocio("u1"))
+    assert result is None
+
+
+def test_fetch_returns_none_when_token_empty(monkeypatch):
+    monkeypatch.setenv("PROFILE_SYNC_ENABLED", "true")
+    monkeypatch.setenv("INTERNAL_API_TOKEN", "")
+    result = asyncio.run(fetch_profile_from_negocio("u1"))
+    assert result is None
+
+
+def test_fetch_returns_none_when_user_id_empty(monkeypatch):
+    monkeypatch.setenv("PROFILE_SYNC_ENABLED", "true")
+    monkeypatch.setenv("INTERNAL_API_TOKEN", "tok")
+    result = asyncio.run(fetch_profile_from_negocio(""))
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_profile_from_negocio — respuestas HTTP
+# ---------------------------------------------------------------------------
+
+@respx.mock
+def test_fetch_returns_profile_on_200(monkeypatch):
+    monkeypatch.setenv("PROFILE_SYNC_ENABLED", "true")
+    monkeypatch.setenv("INTERNAL_API_TOKEN", "test-token")
+    monkeypatch.setenv("BUSINESS_API_BASE_URL", "http://negocio-test")
+    monkeypatch.setenv("BUSINESS_API_PROFILE_PATH", "/internal/users/{userId}/profile")
+
+    payload = {
+        "userId": "u1",
+        "strengths": ["DDD"],
+        "weaknesses": [],
+        "evaluatedConcepts": [
+            {"name": "DDD", "mastery": 70.0, "lastSeenAt": "2026-04-28T10:00:00Z"},
+        ],
+        "updatedAt": "2026-04-28T10:00:00Z",
+    }
+    respx.get("http://negocio-test/internal/users/u1/profile").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+
+    result = asyncio.run(fetch_profile_from_negocio("u1"))
+
+    assert result is not None
+    assert result["user_id"] == "u1"
+    assert result["strengths"] == ["DDD"]
+    assert result["evaluated_concepts"][0]["mastery"] == pytest.approx(0.7, abs=1e-4)
+
+
+@respx.mock
+def test_fetch_returns_none_on_404(monkeypatch):
+    monkeypatch.setenv("PROFILE_SYNC_ENABLED", "true")
+    monkeypatch.setenv("INTERNAL_API_TOKEN", "test-token")
+    monkeypatch.setenv("BUSINESS_API_BASE_URL", "http://negocio-test")
+    monkeypatch.setenv("BUSINESS_API_PROFILE_PATH", "/internal/users/{userId}/profile")
+
+    respx.get("http://negocio-test/internal/users/u1/profile").mock(
+        return_value=httpx.Response(404)
+    )
+
+    result = asyncio.run(fetch_profile_from_negocio("u1"))
+    assert result is None
+
+
+@respx.mock
+def test_fetch_returns_none_on_network_error(monkeypatch):
+    monkeypatch.setenv("PROFILE_SYNC_ENABLED", "true")
+    monkeypatch.setenv("INTERNAL_API_TOKEN", "test-token")
+    monkeypatch.setenv("BUSINESS_API_BASE_URL", "http://negocio-test")
+    monkeypatch.setenv("BUSINESS_API_PROFILE_PATH", "/internal/users/{userId}/profile")
+
+    respx.get("http://negocio-test/internal/users/u1/profile").mock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+
+    result = asyncio.run(fetch_profile_from_negocio("u1"))
+    assert result is None
+
+
+@respx.mock
+def test_fetch_returns_none_on_500(monkeypatch):
+    monkeypatch.setenv("PROFILE_SYNC_ENABLED", "true")
+    monkeypatch.setenv("INTERNAL_API_TOKEN", "test-token")
+    monkeypatch.setenv("BUSINESS_API_BASE_URL", "http://negocio-test")
+    monkeypatch.setenv("BUSINESS_API_PROFILE_PATH", "/internal/users/{userId}/profile")
+
+    respx.get("http://negocio-test/internal/users/u1/profile").mock(
+        return_value=httpx.Response(500, text="Internal Server Error")
+    )
+
+    result = asyncio.run(fetch_profile_from_negocio("u1"))
+    assert result is None

--- a/back/tests/test_profile_schema.py
+++ b/back/tests/test_profile_schema.py
@@ -1,0 +1,97 @@
+"""Tests del schema UserProfileEvaluation (F3-T1)."""
+import pytest
+from pydantic import ValidationError
+
+from src.graph.schemas.profile import (
+    ConceptScore,
+    UserProfileEvaluation,
+    UserProfileSchema,
+)
+
+
+# ---- ConceptScore (de F2-T1, validacion de bordes) -----------------------
+
+def test_concept_score_mastery_in_range():
+    c = ConceptScore(name="X", mastery=0.5)
+    assert c.mastery == 0.5
+
+
+def test_concept_score_mastery_out_of_range_high():
+    with pytest.raises(ValidationError):
+        ConceptScore(name="X", mastery=1.5)
+
+
+def test_concept_score_mastery_out_of_range_low():
+    with pytest.raises(ValidationError):
+        ConceptScore(name="X", mastery=-0.1)
+
+
+# ---- UserProfileEvaluation -----------------------------------------------
+
+def test_evaluation_low_confidence_allows_empty_lists():
+    """Senial debil: confidence < 0.5, listas vacias permitidas."""
+    eval_ = UserProfileEvaluation(confidence=0.3)
+    assert eval_.strengths == []
+    assert eval_.weaknesses == []
+    assert eval_.evaluated_concepts == []
+
+
+def test_evaluation_high_confidence_requires_non_empty():
+    """Confidence >= 0.5 con todo vacio debe rechazarse."""
+    with pytest.raises(ValidationError):
+        UserProfileEvaluation(confidence=0.7)
+
+
+def test_evaluation_high_confidence_with_strengths_only_ok():
+    eval_ = UserProfileEvaluation(
+        confidence=0.7,
+        strengths=[ConceptScore(name="Modularidad", mastery=0.8)],
+    )
+    assert eval_.confidence == 0.7
+    assert len(eval_.strengths) == 1
+
+
+def test_evaluation_high_confidence_with_evaluated_concepts_only_ok():
+    eval_ = UserProfileEvaluation(
+        confidence=0.6,
+        evaluated_concepts=[ConceptScore(name="X", mastery=0.5)],
+    )
+    assert eval_.confidence == 0.6
+
+
+def test_evaluation_confidence_out_of_range():
+    with pytest.raises(ValidationError):
+        UserProfileEvaluation(confidence=1.2)
+
+
+def test_evaluation_delta_from_previous_optional():
+    eval_ = UserProfileEvaluation(confidence=0.3)
+    assert eval_.delta_from_previous == {}
+
+
+def test_evaluation_serializes_round_trip():
+    payload = {
+        "strengths": [{"name": "A", "mastery": 0.8, "evidence": "evi"}],
+        "weaknesses": [{"name": "B", "mastery": 0.2}],
+        "evaluated_concepts": [{"name": "A", "mastery": 0.8}],
+        "confidence": 0.7,
+        "delta_from_previous": {"A": 0.1},
+    }
+    eval_ = UserProfileEvaluation.model_validate(payload)
+    dumped = eval_.model_dump()
+    assert dumped["confidence"] == 0.7
+    assert dumped["delta_from_previous"] == {"A": 0.1}
+    assert dumped["strengths"][0]["name"] == "A"
+
+
+# ---- UserProfileSchema (de F2-T1, smoke) ---------------------------------
+
+def test_user_profile_schema_strips_empty_strings_in_strengths():
+    p = UserProfileSchema(
+        user_id="u1",
+        strengths=["A", "", "  ", "B"],
+        weaknesses=[],
+        evaluated_concepts=[],
+        confidence=0.4,
+    )
+    assert p.strengths == ["A", "B"]

--- a/back/tests/test_profile_sync.py
+++ b/back/tests/test_profile_sync.py
@@ -1,0 +1,231 @@
+"""Tests del cliente HTTP profile_sync (F3-T5)."""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from src.services.profile_sync import (
+    sync_profile,
+    _to_business_payload,
+    _scale_to_business,
+)
+
+
+def _set_env(monkeypatch, **kw):
+    for k, v in kw.items():
+        if v is None:
+            monkeypatch.delenv(k, raising=False)
+        else:
+            monkeypatch.setenv(k, str(v))
+
+
+# ---- _scale_to_business --------------------------------------------------
+
+def test_scale_to_business_basic():
+    assert _scale_to_business(0.0) == 0.0
+    assert _scale_to_business(1.0) == 100.0
+    assert _scale_to_business(0.5) == 50.0
+
+
+def test_scale_clamps_out_of_range():
+    assert _scale_to_business(1.5) == 100.0
+    assert _scale_to_business(-0.5) == 0.0
+
+
+def test_scale_handles_invalid_input():
+    assert _scale_to_business(None) == 0.0
+    assert _scale_to_business("garbage") == 0.0
+
+
+# ---- _to_business_payload ------------------------------------------------
+
+def test_payload_camelcases_and_scales_mastery_original():
+    """Si el concepto trae mastery_original (post-decay), se envia ese valor."""
+    merged = {
+        "user_id": "u1",
+        "strengths": ["A"],
+        "weaknesses": ["B"],
+        "evaluated_concepts": [
+            {
+                "name": "A",
+                "mastery": 0.4,  # decayed (no se envia)
+                "mastery_original": 0.8,  # el valor pre-decay (se envia)
+                "last_seen_at": "2026-04-29T00:00:00+00:00",
+                "evidence": "evi",
+            }
+        ],
+        "confidence": 0.7,
+        "delta_from_previous": {"A": 0.1},
+        "updated_at": "2026-04-29T00:00:00+00:00",
+    }
+    body = _to_business_payload(merged)
+    assert body["confidence"] == 0.7
+    assert body["deltaFromPrevious"] == {"A": 0.1}
+    assert body["updatedAt"] == "2026-04-29T00:00:00+00:00"
+    assert body["strengths"] == ["A"]
+    assert body["weaknesses"] == ["B"]
+    c = body["evaluatedConcepts"][0]
+    assert c["name"] == "A"
+    assert c["mastery"] == 80.0  # 0.8 * 100
+    assert c["lastSeenAt"] == "2026-04-29T00:00:00+00:00"
+    assert c["evidence"] == "evi"
+
+
+def test_payload_falls_back_to_mastery_when_no_original():
+    """Sin mastery_original, usa mastery directo."""
+    merged = {
+        "evaluated_concepts": [{"name": "X", "mastery": 0.5}],
+    }
+    body = _to_business_payload(merged)
+    assert body["evaluatedConcepts"][0]["mastery"] == 50.0
+
+
+def test_payload_includes_decay_rate_when_present():
+    merged = {
+        "evaluated_concepts": [
+            {"name": "X", "mastery": 0.5, "decay_rate": 0.02},
+        ],
+    }
+    body = _to_business_payload(merged)
+    assert body["evaluatedConcepts"][0]["decayRate"] == 0.02
+
+
+def test_payload_omits_optional_fields_when_missing():
+    merged = {"evaluated_concepts": [{"name": "X", "mastery": 0.5}]}
+    body = _to_business_payload(merged)
+    c = body["evaluatedConcepts"][0]
+    assert "lastSeenAt" not in c
+    assert "decayRate" not in c
+    assert "evidence" not in c
+
+
+def test_payload_handles_empty_profile():
+    body = _to_business_payload({})
+    assert body["strengths"] == []
+    assert body["weaknesses"] == []
+    assert body["evaluatedConcepts"] == []
+    assert body["confidence"] == 0.0
+    assert body["deltaFromPrevious"] == {}
+
+
+def test_payload_skips_non_dict_concepts():
+    merged = {"evaluated_concepts": [{"name": "OK", "mastery": 0.5}, "not-a-dict", None]}
+    body = _to_business_payload(merged)
+    assert len(body["evaluatedConcepts"]) == 1
+    assert body["evaluatedConcepts"][0]["name"] == "OK"
+
+
+# ---- sync_profile guards (sin httpx) ------------------------------------
+
+def test_sync_skipped_when_disabled(monkeypatch):
+    _set_env(monkeypatch, PROFILE_SYNC_ENABLED="false", INTERNAL_API_TOKEN="t")
+    out = asyncio.run(sync_profile("u1", {"user_id": "u1"}))
+    assert out is False
+
+
+def test_sync_skipped_when_no_token(monkeypatch):
+    _set_env(monkeypatch, PROFILE_SYNC_ENABLED="true", INTERNAL_API_TOKEN="")
+    out = asyncio.run(sync_profile("u1", {"user_id": "u1"}))
+    assert out is False
+
+
+def test_sync_skipped_when_no_user_id(monkeypatch):
+    _set_env(monkeypatch, PROFILE_SYNC_ENABLED="true", INTERNAL_API_TOKEN="t")
+    out = asyncio.run(sync_profile("", {"user_id": ""}))
+    assert out is False
+
+
+# ---- sync_profile con httpx mockeado ------------------------------------
+
+def _resp(status, body=""):
+    r = MagicMock()
+    r.status_code = status
+    r.text = body
+    return r
+
+
+def _mock_client_with_responses(responses):
+    """Crea un mock de httpx.AsyncClient cuyo PUT retorna `responses` en orden.
+
+    `responses` puede ser una lista de _resp(...) o de excepciones a lanzar.
+    """
+    client = MagicMock()
+    client.put = AsyncMock(side_effect=responses)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm, client
+
+
+def test_sync_success_2xx_first_try(monkeypatch):
+    _set_env(monkeypatch, PROFILE_SYNC_ENABLED="true", INTERNAL_API_TOKEN="tk",
+             BUSINESS_API_BASE_URL="http://nego")
+    cm, client = _mock_client_with_responses([_resp(200)])
+    with patch("src.services.profile_sync.httpx.AsyncClient", return_value=cm):
+        out = asyncio.run(sync_profile("u1", {"user_id": "u1"}))
+    assert out is True
+    assert client.put.await_count == 1
+    args, kwargs = client.put.call_args
+    assert args[0] == "http://nego/internal/users/u1/profile"
+    assert kwargs["headers"]["X-Internal-Token"] == "tk"
+    assert kwargs["headers"]["Content-Type"] == "application/json"
+    # body camelCase
+    assert "evaluatedConcepts" in kwargs["json"]
+
+
+def test_sync_retries_on_5xx_then_success(monkeypatch):
+    _set_env(monkeypatch, PROFILE_SYNC_ENABLED="true", INTERNAL_API_TOKEN="tk")
+    cm, client = _mock_client_with_responses([_resp(503, "down"), _resp(503, "still"), _resp(200)])
+    with patch("src.services.profile_sync.httpx.AsyncClient", return_value=cm), \
+         patch("src.services.profile_sync.asyncio.sleep", new=AsyncMock()):
+        out = asyncio.run(sync_profile("u1", {"user_id": "u1"}))
+    assert out is True
+    assert client.put.await_count == 3
+
+
+def test_sync_gives_up_after_3_attempts(monkeypatch):
+    _set_env(monkeypatch, PROFILE_SYNC_ENABLED="true", INTERNAL_API_TOKEN="tk")
+    cm, client = _mock_client_with_responses([_resp(503), _resp(503), _resp(503)])
+    with patch("src.services.profile_sync.httpx.AsyncClient", return_value=cm), \
+         patch("src.services.profile_sync.asyncio.sleep", new=AsyncMock()):
+        out = asyncio.run(sync_profile("u1", {"user_id": "u1"}))
+    assert out is False
+    assert client.put.await_count == 3
+
+
+def test_sync_handles_connection_error(monkeypatch):
+    _set_env(monkeypatch, PROFILE_SYNC_ENABLED="true", INTERNAL_API_TOKEN="tk")
+    cm, client = _mock_client_with_responses([
+        httpx.ConnectError("refused"),
+        httpx.ConnectError("refused"),
+        httpx.ConnectError("refused"),
+    ])
+    with patch("src.services.profile_sync.httpx.AsyncClient", return_value=cm), \
+         patch("src.services.profile_sync.asyncio.sleep", new=AsyncMock()):
+        out = asyncio.run(sync_profile("u1", {"user_id": "u1"}))
+    assert out is False
+    assert client.put.await_count == 3
+
+
+def test_sync_uses_4xx_as_attempt_too(monkeypatch):
+    """4xx tampoco es exito, pero igual cuenta como intento (sin lanzar)."""
+    _set_env(monkeypatch, PROFILE_SYNC_ENABLED="true", INTERNAL_API_TOKEN="tk")
+    cm, client = _mock_client_with_responses([_resp(401), _resp(401), _resp(401)])
+    with patch("src.services.profile_sync.httpx.AsyncClient", return_value=cm), \
+         patch("src.services.profile_sync.asyncio.sleep", new=AsyncMock()):
+        out = asyncio.run(sync_profile("u1", {"user_id": "u1"}))
+    assert out is False
+    assert client.put.await_count == 3
+
+
+def test_sync_path_template_substitutes_user_id(monkeypatch):
+    _set_env(monkeypatch, PROFILE_SYNC_ENABLED="true", INTERNAL_API_TOKEN="tk",
+             BUSINESS_API_BASE_URL="http://b",
+             BUSINESS_API_PROFILE_PATH="/api/v1/profile/{userId}")
+    cm, client = _mock_client_with_responses([_resp(200)])
+    with patch("src.services.profile_sync.httpx.AsyncClient", return_value=cm):
+        out = asyncio.run(sync_profile("USER-42", {}))
+    assert out is True
+    args, _ = client.put.call_args
+    assert args[0] == "http://b/api/v1/profile/USER-42"

--- a/back/tests/test_python_repl_safety.py
+++ b/back/tests/test_python_repl_safety.py
@@ -1,0 +1,73 @@
+"""Tests del AST guard y subprocess del python_repl_tool (F2-T6)."""
+import os
+
+from src.graph.nodes.tools_professional import _ast_guard, python_repl_tool
+
+
+def test_ast_guard_blocks_import_os():
+    assert _ast_guard("import os") is not None
+
+
+def test_ast_guard_blocks_import_subprocess():
+    assert _ast_guard("import subprocess") is not None
+
+
+def test_ast_guard_blocks_import_socket():
+    assert _ast_guard("import socket") is not None
+
+
+def test_ast_guard_blocks_from_os_import():
+    assert _ast_guard("from os import path") is not None
+
+
+def test_ast_guard_blocks_dunder_import():
+    assert _ast_guard("__import__('os')") is not None
+
+
+def test_ast_guard_blocks_eval():
+    assert _ast_guard("eval('1+1')") is not None
+
+
+def test_ast_guard_blocks_exec():
+    assert _ast_guard("exec('print(1)')") is not None
+
+
+def test_ast_guard_blocks_open():
+    assert _ast_guard("open('x')") is not None
+
+
+def test_ast_guard_allows_safe_arithmetic():
+    assert _ast_guard("x = 1 + 1\nprint(x)") is None
+
+
+def test_ast_guard_allows_safe_imports():
+    assert _ast_guard("import math\nprint(math.pi)") is None
+
+
+def test_ast_guard_reports_syntax_error():
+    out = _ast_guard("def (")
+    assert out is not None and "SyntaxError" in out
+
+
+def test_repl_disabled_by_default():
+    os.environ.pop("ENABLE_PYTHON_REPL", None)
+    out = python_repl_tool.invoke({"code": "print('hi')"})
+    assert "disabled" in out.lower()
+
+
+def test_repl_blocks_dangerous_when_enabled():
+    os.environ["ENABLE_PYTHON_REPL"] = "true"
+    try:
+        out = python_repl_tool.invoke({"code": "import os\nprint(os.getcwd())"})
+        assert "REPL_BLOCKED" in out
+    finally:
+        os.environ["ENABLE_PYTHON_REPL"] = "false"
+
+
+def test_repl_executes_safe_code_when_enabled():
+    os.environ["ENABLE_PYTHON_REPL"] = "true"
+    try:
+        out = python_repl_tool.invoke({"code": "print(1 + 2)"})
+        assert "3" in out
+    finally:
+        os.environ["ENABLE_PYTHON_REPL"] = "false"

--- a/back/tests/test_shadow_agent.py
+++ b/back/tests/test_shadow_agent.py
@@ -1,0 +1,251 @@
+"""Tests del Shadow Agent (F3-T2): merge_profile, cadencia y task entry."""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.graph.schemas.profile import ConceptScore, UserProfileEvaluation
+from src.graph.nodes.profile_shadow import (
+    merge_profile,
+    should_trigger,
+    shadow_eval_async,
+    fire_shadow_eval,
+    _format_messages_window,
+    SHADOW_EVERY_N,
+)
+
+
+# ---- should_trigger ------------------------------------------------------
+
+def test_should_trigger_below_threshold():
+    assert should_trigger(0) is False
+    assert should_trigger(SHADOW_EVERY_N - 1) is False
+
+
+def test_should_trigger_at_threshold():
+    assert should_trigger(SHADOW_EVERY_N) is True
+
+
+def test_should_trigger_above_threshold():
+    assert should_trigger(SHADOW_EVERY_N + 5) is True
+
+
+def test_should_trigger_handles_none():
+    # type: ignore - simulamos un state mal inicializado
+    assert should_trigger(None) is False  # type: ignore[arg-type]
+
+
+# ---- merge_profile -------------------------------------------------------
+
+def _eval(concepts, conf=0.7, strengths=None, weaknesses=None):
+    return UserProfileEvaluation(
+        evaluated_concepts=[ConceptScore(name=n, mastery=m) for n, m in concepts],
+        strengths=[ConceptScore(name=n, mastery=m) for n, m in (strengths or [])],
+        weaknesses=[ConceptScore(name=n, mastery=m) for n, m in (weaknesses or [])],
+        confidence=conf,
+    )
+
+
+def test_merge_profile_with_empty_prev_uses_new_values():
+    new = _eval([("Modularidad", 0.8), ("Caching", 0.3)])
+    out = merge_profile({}, new, alpha=0.7)
+    masterys = {c["name"]: c["mastery"] for c in out["evaluated_concepts"]}
+    assert masterys == {"Modularidad": 0.8, "Caching": 0.3}
+    assert out["delta_from_previous"] == {"Modularidad": 0.8, "Caching": 0.3}
+
+
+def test_merge_profile_weighted_average():
+    prev = {
+        "user_id": "u1",
+        "evaluated_concepts": [
+            {"name": "Modularidad", "mastery": 0.5, "evidence": ""},
+        ],
+    }
+    new = _eval([("Modularidad", 1.0)])
+    out = merge_profile(prev, new, alpha=0.7)
+    # 0.7 * 1.0 + 0.3 * 0.5 = 0.85
+    masterys = {c["name"]: c["mastery"] for c in out["evaluated_concepts"]}
+    assert masterys["Modularidad"] == pytest.approx(0.85, abs=1e-4)
+    assert out["delta_from_previous"]["Modularidad"] == pytest.approx(0.35, abs=1e-4)
+
+
+def test_merge_profile_preserves_concepts_only_in_prev():
+    prev = {
+        "evaluated_concepts": [
+            {"name": "A", "mastery": 0.5},
+            {"name": "B", "mastery": 0.6},
+        ],
+    }
+    new = _eval([("A", 0.9)])
+    out = merge_profile(prev, new, alpha=0.7)
+    names = sorted(c["name"] for c in out["evaluated_concepts"])
+    assert names == ["A", "B"]
+    # B no se evaluo en este turno -> queda intacto
+    b = next(c for c in out["evaluated_concepts"] if c["name"] == "B")
+    assert b["mastery"] == 0.6
+
+
+def test_merge_profile_unions_strengths_case_insensitive():
+    prev = {"strengths": ["Modularidad", "Patrones GoF"]}
+    new = _eval([("Modularidad", 0.8)], strengths=[("modularidad", 0.8), ("Caching", 0.7)])
+    out = merge_profile(prev, new, alpha=0.7)
+    # Modularidad ya estaba; Caching se anade. No se duplica con casefold.
+    assert sorted(s.casefold() for s in out["strengths"]) == sorted(
+        ["modularidad", "patrones gof", "caching"]
+    )
+
+
+def test_merge_profile_writes_updated_at_and_user_id():
+    prev = {"user_id": "u1"}
+    new = _eval([("X", 0.5)])
+    out = merge_profile(prev, new)
+    assert out["user_id"] == "u1"
+    assert "updated_at" in out and out["updated_at"]
+
+
+# ---- _format_messages_window --------------------------------------------
+
+def test_format_messages_window_truncates():
+    from langchain_core.messages import HumanMessage, AIMessage
+
+    msgs = [HumanMessage(content="hola"), AIMessage(content="x" * 1000)]
+    out = _format_messages_window(msgs, window=2)
+    assert "[USER] hola" in out
+    assert "[ASSISTANT]" in out
+    # cada contenido se trunca a 600 chars
+    assistant_line = [ln for ln in out.split("\n\n") if ln.startswith("[ASSISTANT]")][0]
+    assert len(assistant_line) <= 612  # "[ASSISTANT] " + 600 chars
+
+
+def test_format_messages_window_empty():
+    assert _format_messages_window([], window=4) == "(empty conversation)"
+
+
+# ---- shadow_eval_async (con LLM y store mockeados) -----------------------
+
+class _FakeStoreItem:
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeStore:
+    """InMemoryStore-like minimo para el test."""
+
+    def __init__(self, initial=None):
+        self._data = dict(initial or {})
+
+    async def aget(self, ns, key):
+        return _FakeStoreItem(self._data.get((ns, key))) if (ns, key) in self._data else None
+
+    async def aput(self, ns, key, value):
+        self._data[(ns, key)] = value
+
+
+def _make_fake_llm(eval_obj: UserProfileEvaluation):
+    """LLM con .with_structured_output().ainvoke() mockeado."""
+    structured = MagicMock()
+    structured.ainvoke = AsyncMock(return_value=eval_obj)
+    fake_llm = MagicMock()
+    fake_llm.with_structured_output = MagicMock(return_value=structured)
+    return fake_llm
+
+
+def test_shadow_eval_async_writes_merged_profile_to_store():
+    from langchain_core.messages import HumanMessage, AIMessage
+
+    fake_eval = _eval([("Modularidad", 0.9)], strengths=[("Modularidad", 0.9)], conf=0.8)
+    fake_llm = _make_fake_llm(fake_eval)
+    store = _FakeStore()
+
+    msgs = [HumanMessage(content="explicame modularidad"), AIMessage(content="...")]
+
+    out = asyncio.run(shadow_eval_async("u1", msgs, llm_obj=fake_llm, store=store))
+
+    assert out is not None
+    assert out["user_id"] == "u1"
+    assert "Modularidad" in [c["name"] for c in out["evaluated_concepts"]]
+    # Store recibio el escrito
+    persisted = asyncio.run(store.aget(("user", "u1", "profile"), "profile"))
+    assert persisted.value["user_id"] == "u1"
+
+
+def test_shadow_eval_async_skips_when_user_id_empty():
+    from langchain_core.messages import HumanMessage, AIMessage
+
+    fake_eval = _eval([("X", 0.5)])
+    fake_llm = _make_fake_llm(fake_eval)
+    store = _FakeStore()
+    msgs = [HumanMessage(content="hi"), AIMessage(content="hi")]
+
+    out = asyncio.run(shadow_eval_async("", msgs, llm_obj=fake_llm, store=store))
+    assert out is None
+
+
+def test_shadow_eval_async_skips_when_messages_too_few():
+    from langchain_core.messages import HumanMessage
+
+    fake_eval = _eval([("X", 0.5)])
+    fake_llm = _make_fake_llm(fake_eval)
+    store = _FakeStore()
+
+    out = asyncio.run(shadow_eval_async("u1", [HumanMessage(content="hi")], llm_obj=fake_llm, store=store))
+    assert out is None
+
+
+def test_shadow_eval_async_returns_none_on_llm_failure():
+    """Si el evaluador lanza, NO se escribe al Store (perfil previo intacto)."""
+    from langchain_core.messages import HumanMessage, AIMessage
+
+    structured = MagicMock()
+    structured.ainvoke = AsyncMock(side_effect=RuntimeError("LLM down"))
+    fake_llm = MagicMock()
+    fake_llm.with_structured_output = MagicMock(return_value=structured)
+
+    pre_existing = {"user_id": "u1", "strengths": ["Original"], "evaluated_concepts": []}
+    store = _FakeStore(initial={(("user", "u1", "profile"), "profile"): pre_existing})
+
+    msgs = [HumanMessage(content="x"), AIMessage(content="y")]
+    out = asyncio.run(shadow_eval_async("u1", msgs, llm_obj=fake_llm, store=store))
+    assert out is None
+    # Perfil previo intacto
+    persisted = asyncio.run(store.aget(("user", "u1", "profile"), "profile"))
+    assert persisted.value["strengths"] == ["Original"]
+
+
+def test_shadow_eval_async_merges_with_existing_profile():
+    from langchain_core.messages import HumanMessage, AIMessage
+
+    pre_existing = {
+        "user_id": "u1",
+        "strengths": ["A"],
+        "weaknesses": [],
+        "evaluated_concepts": [{"name": "A", "mastery": 0.4}],
+    }
+    fake_eval = _eval([("A", 1.0), ("B", 0.5)], strengths=[("B", 0.5)], conf=0.8)
+    fake_llm = _make_fake_llm(fake_eval)
+    store = _FakeStore(initial={(("user", "u1", "profile"), "profile"): pre_existing})
+
+    msgs = [HumanMessage(content="hola"), AIMessage(content="ok")]
+    out = asyncio.run(shadow_eval_async("u1", msgs, llm_obj=fake_llm, store=store))
+    assert out is not None
+    masterys = {c["name"]: c["mastery"] for c in out["evaluated_concepts"]}
+    # A: 0.7*1.0 + 0.3*0.4 = 0.82
+    assert masterys["A"] == pytest.approx(0.82, abs=1e-4)
+    assert masterys["B"] == 0.5
+    # Strengths union (A pre-existing + B nuevo)
+    assert sorted(s.casefold() for s in out["strengths"]) == ["a", "b"]
+
+
+# ---- fire_shadow_eval (sync trigger from unifier) ------------------------
+
+def test_fire_shadow_eval_skips_when_below_threshold():
+    state = {"turn_count_since_eval": 0, "user_id": "u1", "messages": []}
+    # No hay loop activo -> deberia retornar None sin lanzar
+    result = fire_shadow_eval(state, final_text="x")
+    assert result is None
+
+
+def test_fire_shadow_eval_skips_when_no_user_id():
+    state = {"turn_count_since_eval": 999, "user_id": "", "messages": []}
+    result = fire_shadow_eval(state, final_text="x")
+    assert result is None

--- a/back/tests/test_store_cross_thread.py
+++ b/back/tests/test_store_cross_thread.py
@@ -1,0 +1,54 @@
+"""F1-T4: Verificacion de lectura cross-thread del Store.
+
+Estos tests no requieren `pytest-asyncio`. Cada caso ejecuta su corutina via
+`asyncio.run(...)` desde una funcion sincrona estandar de pytest.
+"""
+import asyncio
+
+from langgraph.store.memory import InMemoryStore
+
+
+def test_store_cross_thread_profile_roundtrip():
+    """Escribe un perfil bajo ("user", "u1", "profile") y lo lee de vuelta sin
+    referencia al thread_id del checkpointer (cross-thread por construccion)."""
+
+    async def run():
+        store = InMemoryStore()
+        ns = ("user", "u1", "profile")
+        payload = {"strengths": ["X"], "weaknesses": ["Y"]}
+        await store.aput(ns, key="profile", value=payload)
+        item = await store.aget(ns, key="profile")
+        assert item is not None
+        assert item.value == payload
+
+    asyncio.run(run())
+
+
+def test_store_namespaces_are_isolated_per_user():
+    """Verifica que dos usuarios distintos no se ven entre si."""
+
+    async def run():
+        store = InMemoryStore()
+        await store.aput(("user", "u1", "profile"), key="profile", value={"v": 1})
+        await store.aput(("user", "u2", "profile"), key="profile", value={"v": 2})
+        item1 = await store.aget(("user", "u1", "profile"), key="profile")
+        item2 = await store.aget(("user", "u2", "profile"), key="profile")
+        assert item1 is not None and item1.value == {"v": 1}
+        assert item2 is not None and item2.value == {"v": 2}
+
+    asyncio.run(run())
+
+
+def test_store_routines_namespace_supported():
+    """Verifica que el namespace ("user", user_id, "routines") es escribible y
+    legible, en linea con la convencion documentada en docs_back/store.md."""
+
+    async def run():
+        store = InMemoryStore()
+        ns = ("user", "u1", "routines")
+        await store.aput(ns, key="r1", value={"title": "Reto 1"})
+        item = await store.aget(ns, key="r1")
+        assert item is not None
+        assert item.value["title"] == "Reto 1"
+
+    asyncio.run(run())

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true

--- a/postman/Phase2_Modes.postman_collection.json
+++ b/postman/Phase2_Modes.postman_collection.json
@@ -1,0 +1,379 @@
+{
+  "info": {
+    "name": "ArchIA - Phase 2 Modes & Auto-Routing",
+    "description": "Coleccion para validar Fase 2 (modos Tutor/Profesional + auto-routing).\n\nPRECONDICIONES:\n- Backend IA corriendo: `python -m uvicorn src.main:app --port 8000` desde `archIABack/back/`.\n- Variable de coleccion `baseUrl` apuntando al puerto correcto.\n- En Postman > Settings > General, activa `Allow streaming responses for chunked responses` para ver los eventos SSE en tiempo real.\n\nCada request a /message espera respuesta SSE con varios eventos `data: {...}`. El evento final tiene `\"type\":\"complete\"` y trae los campos `mode` y `mode_suggestion`. Los tests de cada request validan los puntos clave del contrato.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8000",
+      "type": "string"
+    },
+    {
+      "key": "session_id",
+      "value": "phase2-smoke-{{$timestamp}}",
+      "type": "string"
+    },
+    {
+      "key": "user_id",
+      "value": "smoke-user-1",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "0. Health Check",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/health",
+          "host": ["{{baseUrl}}"],
+          "path": ["health"]
+        },
+        "description": "Sanity check: backend levantado y lifespan completo (AsyncSqliteSaver + InMemoryStore listos)."
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('200 OK', () => pm.response.to.have.status(200));"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "1. Modo default (sin mode -> professional)",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            { "key": "message", "value": "Dame un resumen de microservicios", "type": "text" },
+            { "key": "session_id", "value": "{{session_id}}-default", "type": "text" },
+            { "key": "user_id", "value": "{{user_id}}", "type": "text" }
+          ]
+        },
+        "url": {
+          "raw": "{{baseUrl}}/message",
+          "host": ["{{baseUrl}}"],
+          "path": ["message"]
+        },
+        "description": "Sin enviar `mode`, el handler debe defaultear a `professional`. El evento SSE `complete` debe traer `\"mode\":\"professional\"`."
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('200 OK', () => pm.response.to.have.status(200));",
+              "pm.test('Default mode is professional', () => {",
+              "  pm.expect(pm.response.text()).to.include('\"mode\":\"professional\"');",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "2. Modo Tutor explicito",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            { "key": "message", "value": "Quiero entender que es un patron de circuit breaker", "type": "text" },
+            { "key": "session_id", "value": "{{session_id}}-tutor", "type": "text" },
+            { "key": "user_id", "value": "{{user_id}}", "type": "text" },
+            { "key": "mode", "value": "tutor", "type": "text" }
+          ]
+        },
+        "url": {
+          "raw": "{{baseUrl}}/message",
+          "host": ["{{baseUrl}}"],
+          "path": ["message"]
+        },
+        "description": "Modo Tutor explicito. El sistema prompt debe inyectar TUTOR_SYSTEM_PROMPT (preguntas socraticas, analogias). El evento `complete` trae `\"mode\":\"tutor\"`."
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('200 OK', () => pm.response.to.have.status(200));",
+              "pm.test('Mode echoed as tutor', () => {",
+              "  pm.expect(pm.response.text()).to.include('\"mode\":\"tutor\"');",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "3. Modo Professional explicito",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            { "key": "message", "value": "Define un ASR de latencia para un checkout de e-commerce", "type": "text" },
+            { "key": "session_id", "value": "{{session_id}}-pro", "type": "text" },
+            { "key": "user_id", "value": "{{user_id}}", "type": "text" },
+            { "key": "mode", "value": "professional", "type": "text" }
+          ]
+        },
+        "url": {
+          "raw": "{{baseUrl}}/message",
+          "host": ["{{baseUrl}}"],
+          "path": ["message"]
+        },
+        "description": "Modo Profesional explicito. Inyecta PROFESSIONAL_SYSTEM_PROMPT (consultor senior L4+, solucion concreta primero). Tools `python_repl_tool` y `local_rag_advanced` quedan disponibles en el investigador (sin pedir glossary/cite)."
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('200 OK', () => pm.response.to.have.status(200));",
+              "pm.test('Mode echoed as professional', () => {",
+              "  pm.expect(pm.response.text()).to.include('\"mode\":\"professional\"');",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "4. Mode invalido (400)",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            { "key": "message", "value": "hola", "type": "text" },
+            { "key": "session_id", "value": "{{session_id}}-bad", "type": "text" },
+            { "key": "mode", "value": "ninja", "type": "text" }
+          ]
+        },
+        "url": {
+          "raw": "{{baseUrl}}/message",
+          "host": ["{{baseUrl}}"],
+          "path": ["message"]
+        },
+        "description": "El handler debe rechazar valores fuera de `tutor`/`professional` con HTTP 400."
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('400 Bad Request', () => pm.response.to.have.status(400));",
+              "pm.test('Detail mentions Invalid mode', () => {",
+              "  const body = pm.response.json();",
+              "  pm.expect(body.detail).to.match(/Invalid mode/i);",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "5. Auto-routing: en Tutor con intencion profesional",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            { "key": "message", "value": "Dame el codigo para implementar un circuit breaker en Java con Resilience4j", "type": "text" },
+            { "key": "session_id", "value": "{{session_id}}-route-pro", "type": "text" },
+            { "key": "user_id", "value": "{{user_id}}", "type": "text" },
+            { "key": "mode", "value": "tutor", "type": "text" }
+          ]
+        },
+        "url": {
+          "raw": "{{baseUrl}}/message",
+          "host": ["{{baseUrl}}"],
+          "path": ["message"]
+        },
+        "description": "Usuario en Tutor pero pide solucion concreta (`dame el codigo`, `implementa`). El classifier debe emitir `mode_suggestion=professional` SIN cambiar el modo activo. El evento `complete` trae `mode=tutor` y `mode_suggestion=professional`."
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('200 OK', () => pm.response.to.have.status(200));",
+              "pm.test('Active mode stays tutor (no auto-switch)', () => {",
+              "  pm.expect(pm.response.text()).to.include('\"mode\":\"tutor\"');",
+              "});",
+              "pm.test('Suggestion is professional', () => {",
+              "  pm.expect(pm.response.text()).to.include('\"mode_suggestion\":\"professional\"');",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "6. Auto-routing: en Profesional con intencion tutor",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            { "key": "message", "value": "Explicame que significa exactamente la latencia p95 con una analogia", "type": "text" },
+            { "key": "session_id", "value": "{{session_id}}-route-tut", "type": "text" },
+            { "key": "user_id", "value": "{{user_id}}", "type": "text" },
+            { "key": "mode", "value": "professional", "type": "text" }
+          ]
+        },
+        "url": {
+          "raw": "{{baseUrl}}/message",
+          "host": ["{{baseUrl}}"],
+          "path": ["message"]
+        },
+        "description": "Usuario en Profesional pero pide pedagogia (`explicame`, `que significa`). El classifier emite `mode_suggestion=tutor`."
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('200 OK', () => pm.response.to.have.status(200));",
+              "pm.test('Active mode stays professional', () => {",
+              "  pm.expect(pm.response.text()).to.include('\"mode\":\"professional\"');",
+              "});",
+              "pm.test('Suggestion is tutor', () => {",
+              "  pm.expect(pm.response.text()).to.include('\"mode_suggestion\":\"tutor\"');",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "7. Auto-routing supresion: ya en Tutor con intencion tutor",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            { "key": "message", "value": "Explicame que es un saga pattern, no entiendo el concepto", "type": "text" },
+            { "key": "session_id", "value": "{{session_id}}-route-noop", "type": "text" },
+            { "key": "user_id", "value": "{{user_id}}", "type": "text" },
+            { "key": "mode", "value": "tutor", "type": "text" }
+          ]
+        },
+        "url": {
+          "raw": "{{baseUrl}}/message",
+          "host": ["{{baseUrl}}"],
+          "path": ["message"]
+        },
+        "description": "Usuario en Tutor con mensaje pedagogico. La sugerencia se suprime (mode_suggestion=null) para no spammear el Snackbar de F7-T2. `mode_suggestion` debe ser null en el JSON."
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('200 OK', () => pm.response.to.have.status(200));",
+              "pm.test('Active mode is tutor', () => {",
+              "  pm.expect(pm.response.text()).to.include('\"mode\":\"tutor\"');",
+              "});",
+              "pm.test('Suggestion is null (suppressed)', () => {",
+              "  pm.expect(pm.response.text()).to.include('\"mode_suggestion\":null');",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "8a. Persistencia thread_id - PRIMER turno",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            { "key": "message", "value": "Mi sistema es un e-commerce con flash sales. Recordalo.", "type": "text" },
+            { "key": "session_id", "value": "{{session_id}}-thread-persist", "type": "text" },
+            { "key": "user_id", "value": "{{user_id}}", "type": "text" },
+            { "key": "mode", "value": "professional", "type": "text" }
+          ]
+        },
+        "url": {
+          "raw": "{{baseUrl}}/message",
+          "host": ["{{baseUrl}}"],
+          "path": ["message"]
+        },
+        "description": "Primer turno bajo un session_id especifico. El AsyncSqliteSaver persiste el checkpoint. Tras correr este request, verifica manualmente que `back/state_db/graph_checkpoints.db` crece de tamanio."
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('200 OK', () => pm.response.to.have.status(200));",
+              "pm.test('thread_id echoed', () => {",
+              "  pm.expect(pm.response.text()).to.include('thread_id');",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "8b. Persistencia thread_id - SEGUNDO turno (mismo session_id)",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            { "key": "message", "value": "Que fue lo ultimo que te dije sobre mi sistema?", "type": "text" },
+            { "key": "session_id", "value": "{{session_id}}-thread-persist", "type": "text" },
+            { "key": "user_id", "value": "{{user_id}}", "type": "text" },
+            { "key": "mode", "value": "professional", "type": "text" }
+          ]
+        },
+        "url": {
+          "raw": "{{baseUrl}}/message",
+          "host": ["{{baseUrl}}"],
+          "path": ["message"]
+        },
+        "description": "Segundo turno con el MISMO session_id. El checkpointer rehidrata el thread y el agente debe poder referenciar el contexto del turno anterior (e-commerce con flash sales). Prueba indirecta de F1-T3."
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('200 OK', () => pm.response.to.have.status(200));"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "chromadb (>=1.4.1,<2.0.0)",
     "langgraph-checkpoint-postgres (>=3.0.4,<4.0.0)",
     "httpx (>=0.28.1,<0.29.0)",
+    "respx (>=0.20,<1.0)",
     "pymupdf (>=1.26.7,<2.0.0)",
     "pypdf (>=6.6.2,<7.0.0)",
     "graphviz (>=0.20.3,<1.0.0)",


### PR DESCRIPTION
Integrates tutor/professional mode (shadow agent, user profiles, async boot/unifier, mode-aware prompts) alongside the IntakeNode feature. Intake phase is now gated to professional mode only — tutor mode skips the intake questionnaire and routes through normal supervisor logic.